### PR TITLE
Changes to __main__ entry point

### DIFF
--- a/fast_carpenter/__main__.py
+++ b/fast_carpenter/__main__.py
@@ -59,6 +59,7 @@ def create_parser():
 
     return parser
 
+
 def main(args=None):
     args = create_parser().parse_args(args)
 
@@ -71,6 +72,7 @@ def main(args=None):
     _, ret_val = run_carpenter(sequence, datasets, args)
     print(ret_val)
     return 0
+
 
 def run_carpenter(sequence, datasets, args):
     process = atup.AtUproot(args.outdir,
@@ -87,6 +89,7 @@ def run_carpenter(sequence, datasets, args):
     sequence = [(s, s.collector() if hasattr(s, "collector") else DummyCollector()) for s in sequence]
     ret_val = process.run(datasets, sequence)
     return sequence, ret_val
+
 
 if __name__ == "__main__":
     main()

--- a/fast_carpenter/__main__.py
+++ b/fast_carpenter/__main__.py
@@ -21,7 +21,7 @@ class DummyCollector():
         pass
 
 
-def process_args(args=None):
+def create_parser():
     from argparse import ArgumentParser, Action
 
     class StagesHelp(Action):
@@ -56,11 +56,50 @@ def process_args(args=None):
                         help="Print help specific to the available stages")
     parser.add_argument("--help-stages-full", action=StagesHelp, metavar="stage",
                         help="Print the full help specific to the available stages")
-    return parser.parse_args()
+
+    return parser
+
+
+def process_args(args=None):
+    from argparse import ArgumentParser, Action
+
+    class StagesHelp(Action):
+        def __call__(self, parser, namespace, values, option_string=None):
+            full_output = option_string == "--help-stages-full"
+            help_stages(values, full_output=full_output)
+            sys.exit(0)
+
+    parser = argumentparser(description=__doc__)
+    parser.add_argument("dataset_cfg", type=str,
+                        help="dataset config to run over")
+    parser.add_argument("sequence_cfg", type=str,
+                        help="config for how to process events")
+    parser.add_argument("--outdir", default="output", type=str,
+                        help="where to save the results")
+    parser.add_argument("--mode", default="multiprocessing", type=str,
+                        help="which mode to run in (multiprocessing, htcondor, sge)")
+    parser.add_argument("--ncores", default=0, type=int,
+                        help="number of cores to run on")
+    parser.add_argument("--nblocks-per-dataset", default=-1, type=int,
+                        help="number of blocks per dataset")
+    parser.add_argument("--nblocks-per-sample", default=-1, type=int,
+                        help="number of blocks per sample")
+    parser.add_argument("--blocksize", default=1000000, type=int,
+                        help="number of events per block")
+    parser.add_argument("--quiet", default=false, action='store_true',
+                        help="keep progress report quiet")
+    parser.add_argument("--profile", default=false, action='store_true',
+                        help="profile the code")
+    parser.add_argument("--help-stages", nargs="?", default=none, action=stageshelp,
+                        metavar="stage-name-regex",
+                        help="print help specific to the available stages")
+    parser.add_argument("--help-stages-full", action=stageshelp, metavar="stage",
+                        help="print the full help specific to the available stages")
+    return parser.parse_args(args)
 
 
 def main(args=None):
-    args = process_args(args)
+    args = creater_parser().parse_args(args)
 
     sequence = fast_flow.read_sequence_yaml(args.sequence_cfg, output_dir=args.outdir)
 

--- a/fast_carpenter/__main__.py
+++ b/fast_carpenter/__main__.py
@@ -99,7 +99,7 @@ def process_args(args=None):
 
 
 def main(args=None):
-    args = creater_parser().parse_args(args)
+    args = create_parser().parse_args(args)
 
     sequence = fast_flow.read_sequence_yaml(args.sequence_cfg, output_dir=args.outdir)
 
@@ -107,6 +107,11 @@ def main(args=None):
 
     mkdir_p(args.outdir)
 
+    _, ret_val = run_carpenter(sequence, datasets, args)
+    print(ret_val)
+    return 0
+
+def run_carpenter(sequence, datasets, args):
     process = atup.AtUproot(args.outdir,
                             quiet=args.quiet,
                             parallel_mode=args.mode,
@@ -120,9 +125,7 @@ def main(args=None):
 
     sequence = [(s, s.collector() if hasattr(s, "collector") else DummyCollector()) for s in sequence]
     ret_val = process.run(datasets, sequence)
-    print(ret_val)
-    return 0
-
+    return sequence, ret_val
 
 if __name__ == "__main__":
     main()

--- a/fast_carpenter/__main__.py
+++ b/fast_carpenter/__main__.py
@@ -59,45 +59,6 @@ def create_parser():
 
     return parser
 
-
-def process_args(args=None):
-    from argparse import ArgumentParser, Action
-
-    class StagesHelp(Action):
-        def __call__(self, parser, namespace, values, option_string=None):
-            full_output = option_string == "--help-stages-full"
-            help_stages(values, full_output=full_output)
-            sys.exit(0)
-
-    parser = argumentparser(description=__doc__)
-    parser.add_argument("dataset_cfg", type=str,
-                        help="dataset config to run over")
-    parser.add_argument("sequence_cfg", type=str,
-                        help="config for how to process events")
-    parser.add_argument("--outdir", default="output", type=str,
-                        help="where to save the results")
-    parser.add_argument("--mode", default="multiprocessing", type=str,
-                        help="which mode to run in (multiprocessing, htcondor, sge)")
-    parser.add_argument("--ncores", default=0, type=int,
-                        help="number of cores to run on")
-    parser.add_argument("--nblocks-per-dataset", default=-1, type=int,
-                        help="number of blocks per dataset")
-    parser.add_argument("--nblocks-per-sample", default=-1, type=int,
-                        help="number of blocks per sample")
-    parser.add_argument("--blocksize", default=1000000, type=int,
-                        help="number of events per block")
-    parser.add_argument("--quiet", default=false, action='store_true',
-                        help="keep progress report quiet")
-    parser.add_argument("--profile", default=false, action='store_true',
-                        help="profile the code")
-    parser.add_argument("--help-stages", nargs="?", default=none, action=stageshelp,
-                        metavar="stage-name-regex",
-                        help="print help specific to the available stages")
-    parser.add_argument("--help-stages-full", action=stageshelp, metavar="stage",
-                        help="print the full help specific to the available stages")
-    return parser.parse_args(args)
-
-
 def main(args=None):
     args = create_parser().parse_args(args)
 

--- a/fast_carpenter/summary/binned_dataframe.py
+++ b/fast_carpenter/summary/binned_dataframe.py
@@ -3,7 +3,6 @@ Summarize the data by producing binned and possibly weighted counts of the data.
 """
 import os
 import pandas as pd
-import numpy as np
 from . import binning_config as cfg
 
 

--- a/fast_carpenter/summary/binned_dataframe.py
+++ b/fast_carpenter/summary/binned_dataframe.py
@@ -3,6 +3,7 @@ Summarize the data by producing binned and possibly weighted counts of the data.
 """
 import os
 import pandas as pd
+import numpy as np
 from . import binning_config as cfg
 
 
@@ -76,7 +77,7 @@ def densify_dataframe(in_df, binnings):
         if bins is None:
             index_values.append(in_index.unique(dim))
             continue
-        index_values.append(pd.IntervalIndex.from_breaks(bins, closed="left"))
+        index_values.append(pd.IntervalIndex.from_breaks(np.round(bins, 3), closed="left"))
     out_index = pd.MultiIndex.from_product(index_values, names=in_index.names)
     out_df = in_df.reindex(index=out_index, copy=False)
     return out_df

--- a/fast_carpenter/summary/binned_dataframe.py
+++ b/fast_carpenter/summary/binned_dataframe.py
@@ -77,7 +77,7 @@ def densify_dataframe(in_df, binnings):
         if bins is None:
             index_values.append(in_index.unique(dim))
             continue
-        index_values.append(pd.IntervalIndex.from_breaks(np.round(bins, 3), closed="left"))
+        index_values.append(pd.IntervalIndex.from_breaks(bins, closed="left"))
     out_index = pd.MultiIndex.from_product(index_values, names=in_index.names)
     out_df = in_df.reindex(index=out_index, copy=False)
     return out_df


### PR DESCRIPTION
Core atuproot functionality is moved into a separate function `run_carpenter(sequence, datasets, args)`, which returns the processing sequence. This allows fast_carpenter to be used inside other scripts/notebooks. 

args passed to `__main__(args)` function outside of the cli are now parsed. 