### PR TITLE
Use numexpr when defining binning

### DIFF
--- a/fast_carpenter/summary/binned_dataframe.py
+++ b/fast_carpenter/summary/binned_dataframe.py
@@ -210,7 +210,7 @@ def _bin_values(data, dimensions, binnings, weights, out_dimensions=None, out_we
             final_bin_dims.append(dimension)
             continue
         out_dimension = dimension + "_bins"
-        data[out_dimension] = pd.cut(data.eval(dimension), binning, right=False)
+        data[out_dimension] = pd.cut(data.eval(dimension, engine='numexpr'), binning, right=False)
         final_bin_dims.append(out_dimension)
 
     if weights:

--- a/fast_carpenter/summary/binned_dataframe.py
+++ b/fast_carpenter/summary/binned_dataframe.py
@@ -158,12 +158,13 @@ class BinnedDataframe():
         return Collector(outfilename, self._dataset_col, binnings=binnings)
 
     def event(self, chunk):
+
+        all_inputs = [key for key in chunk.tree.keys() if any(key.decode() in dim for dim in self._bin_dims)]
         if chunk.config.dataset.eventtype == "mc":
             weights = list(self._weights.values())
-            all_inputs = self._bin_dims + weights
+            all_inputs += weights
         else:
             weights = None
-            all_inputs = self._bin_dims
 
         data = chunk.tree.pandas.df(all_inputs)
 
@@ -209,7 +210,7 @@ def _bin_values(data, dimensions, binnings, weights, out_dimensions=None, out_we
             final_bin_dims.append(dimension)
             continue
         out_dimension = dimension + "_bins"
-        data[out_dimension] = pd.cut(data[dimension], binning, right=False)
+        data[out_dimension] = pd.cut(data.eval(dimension), binning, right=False)
         final_bin_dims.append(out_dimension)
 
     if weights:

--- a/fast_carpenter/summary/binning_config.py
+++ b/fast_carpenter/summary/binning_config.py
@@ -62,7 +62,8 @@ def bin_one_dimension(low=None, high=None, nbins=None, edges=None,
     # - bins: {nbins: 6 , low: 1  , high: 5 , overflow: True}
     # - bins: {edges: [0, 200., 900], overflow: True}
     if all([x is not None for x in (nbins, low, high)]):
-        low, high, nbins = pd.eval(low, engine='numexpr'), pd.eval(high, engine='numexpr'), pd.eval(nbins, engine='numexpr')
+        low, high, nbins = (pd.eval(low, engine='numexpr'),
+                            pd.eval(high, engine='numexpr'), pd.eval(nbins, engine='numexpr'))
         bin_obj = np.linspace(low, high, nbins + 1)
     elif edges:
         # array are fixed to float type, to be consistent with the float-type underflow and overflow bins

--- a/fast_carpenter/summary/binning_config.py
+++ b/fast_carpenter/summary/binning_config.py
@@ -1,5 +1,6 @@
 import six
 import numpy as np
+import pandas as pd
 
 
 class BadBinnedDataframeConfig(Exception):
@@ -61,7 +62,8 @@ def bin_one_dimension(low=None, high=None, nbins=None, edges=None,
     # - bins: {nbins: 6 , low: 1  , high: 5 , overflow: True}
     # - bins: {edges: [0, 200., 900], overflow: True}
     if all([x is not None for x in (nbins, low, high)]):
-        bin_obj = np.linspace(eval(str(low)), eval(str(high)), eval(str(nbins)) + 1)
+        low, high, nbins = pd.eval(low, engine='numexpr'), pd.eval(high, engine='numexpr'), pd.eval(nbins, engine='numexpr')
+        bin_obj = np.linspace(low, high, nbins + 1)
     elif edges:
         # array are fixed to float type, to be consistent with the float-type underflow and overflow bins
         bin_obj = np.array(edges, "f")

--- a/fast_carpenter/summary/binning_config.py
+++ b/fast_carpenter/summary/binning_config.py
@@ -61,7 +61,7 @@ def bin_one_dimension(low=None, high=None, nbins=None, edges=None,
     # - bins: {nbins: 6 , low: 1  , high: 5 , overflow: True}
     # - bins: {edges: [0, 200., 900], overflow: True}
     if all([x is not None for x in (nbins, low, high)]):
-        bin_obj = np.linspace(low, high, nbins + 1)
+        bin_obj = np.linspace(eval(str(low)), eval(str(high)), eval(str(nbins)) + 1)
     elif edges:
         # array are fixed to float type, to be consistent with the float-type underflow and overflow bins
         bin_obj = np.array(edges, "f")

--- a/tests/summary/dummy_binning_descriptions.py
+++ b/tests/summary/dummy_binning_descriptions.py
@@ -3,7 +3,8 @@ bins_met_px = {"in": "MET_px", "out": "met_px", "bins": dict(nbins=10, low=0, hi
 
 bins_py = {"in": "Jet_Py", "out": "py_leadJet", "bins": dict(edges=[0, 20., 100.], overflow=True), "index": 0}
 
-bins_electron_pT = {"in": "sqrt(Electron_Px**2 + Electron_Py**2)", "out": "electron_pT", "bins": dict(nbins=200/10., low=0.0+0.0, high=2.0*10**2)}
+bins_electron_pT = {"in": "sqrt(Electron_Px**2 + Electron_Py**2)", "out": "electron_pT",
+                    "bins": dict(nbins=200/10., low=0.0+0.0, high=2.0*10**2)}
 
 bins_nmuon = {"in": "NMuon", "out": "nmuon"}
 

--- a/tests/summary/dummy_binning_descriptions.py
+++ b/tests/summary/dummy_binning_descriptions.py
@@ -3,6 +3,7 @@ bins_met_px = {"in": "MET_px", "out": "met_px", "bins": dict(nbins=10, low=0, hi
 
 bins_py = {"in": "Jet_Py", "out": "py_leadJet", "bins": dict(edges=[0, 20., 100.], overflow=True), "index": 0}
 
+bins_electron_pT = {"in": "sqrt(Electron_Px**2 + Electron_Py**2)", "out": "electron_pT", "bins": dict(nbins=200/10., low=0.0+0.0, high=2.0*10**2)}
 
 bins_nmuon = {"in": "NMuon", "out": "nmuon"}
 

--- a/tests/summary/dummy_binning_descriptions.py
+++ b/tests/summary/dummy_binning_descriptions.py
@@ -4,7 +4,7 @@ bins_met_px = {"in": "MET_px", "out": "met_px", "bins": dict(nbins=10, low=0, hi
 bins_py = {"in": "Jet_Py", "out": "py_leadJet", "bins": dict(edges=[0, 20., 100.], overflow=True), "index": 0}
 
 bins_electron_pT = {"in": "sqrt(Electron_Px**2 + Electron_Py**2)", "out": "electron_pT",
-                    "bins": dict(nbins=200/10., low=0.0+0.0, high=2.0*10**2)}
+                    "bins": dict(nbins='20', low=0.0, high='2.0*10**2')}
 
 bins_nmuon = {"in": "NMuon", "out": "nmuon"}
 

--- a/tests/summary/test_binned_dataframe.py
+++ b/tests/summary/test_binned_dataframe.py
@@ -20,6 +20,7 @@ def config_2():
                          binning.bins_nmuon],
                 weights=binning.weight_dict)
 
+
 @pytest.fixture
 def config_3():
     return dict(binning=[binning.bins_electron_pT],
@@ -47,6 +48,7 @@ def test_BinnedDataframe(binned_df_1, tmpdir):
 @pytest.fixture
 def binned_df_2(tmpdir, config_2):
     return bdf.BinnedDataframe("binned_df_2", out_dir="somewhere", **config_2)
+
 
 def test_BinnedDataframe_run_mc(binned_df_1, tmpdir, infile):
     chunk = FakeBEEvent(infile, "mc")
@@ -131,9 +133,11 @@ def test_binneddataframe_run_twice_data_mc(run_twice_data_mc, dataset_col, pad_m
     # htemp->GetMean() * htemp->GetEntries()
     assert totals["EventWeight:sumw"] == pytest.approx(231.91339 * 2)
 
+
 @pytest.fixture
 def binned_df_3(tmpdir, config_3):
     return bdf.BinnedDataframe("binned_df_3", out_dir="somewhere", **config_3)
+
 
 def test_BinnedDataframe_numexpr(binned_df_3, tmpdir):
     assert binned_df_3.name == "binned_df_3"
@@ -144,6 +148,7 @@ def test_BinnedDataframe_numexpr(binned_df_3, tmpdir):
     assert binned_df_3._binnings[0][-2] == 200
     assert len(binned_df_3._binnings[0]) == 2*10 + 1 + 2
     assert len(binned_df_3._weights) == 1
+
 
 def test_BinnedDataframe_numexpr_run_mc(binned_df_3, tmpdir, infile):
     chunk = FakeBEEvent(infile, "mc")

--- a/tests/summary/test_binned_dataframe.py
+++ b/tests/summary/test_binned_dataframe.py
@@ -1,3 +1,5 @@
+import pandas as pd
+import numpy as np
 import pytest
 import fast_carpenter.summary.binned_dataframe as bdf
 from . import dummy_binning_descriptions as binning
@@ -16,6 +18,11 @@ def config_2():
     return dict(binning=[binning.bins_py,
                          binning.bins_met_px,
                          binning.bins_nmuon],
+                weights=binning.weight_dict)
+
+@pytest.fixture
+def config_3():
+    return dict(binning=[binning.bins_electron_pT],
                 weights=binning.weight_dict)
 
 
@@ -40,7 +47,6 @@ def test_BinnedDataframe(binned_df_1, tmpdir):
 @pytest.fixture
 def binned_df_2(tmpdir, config_2):
     return bdf.BinnedDataframe("binned_df_2", out_dir="somewhere", **config_2)
-
 
 def test_BinnedDataframe_run_mc(binned_df_1, tmpdir, infile):
     chunk = FakeBEEvent(infile, "mc")
@@ -124,3 +130,29 @@ def test_binneddataframe_run_twice_data_mc(run_twice_data_mc, dataset_col, pad_m
     # events->Draw("EventWeight * (Jet_Py/Jet_Py)>>htemp", "", "goff")
     # htemp->GetMean() * htemp->GetEntries()
     assert totals["EventWeight:sumw"] == pytest.approx(231.91339 * 2)
+
+@pytest.fixture
+def binned_df_3(tmpdir, config_3):
+    return bdf.BinnedDataframe("binned_df_3", out_dir="somewhere", **config_3)
+
+def test_BinnedDataframe_numexpr(binned_df_3, tmpdir):
+    assert binned_df_3.name == "binned_df_3"
+    assert len(binned_df_3._binnings) == 1
+    # bin length for electron_pT nbins, plus 1 for edge, plus 2 for +-inf
+    assert binned_df_3._bin_dims[0] == "sqrt(Electron_Px**2 + Electron_Py**2)"
+    assert binned_df_3._binnings[0][1] == 0.0
+    assert binned_df_3._binnings[0][-2] == 200
+    assert len(binned_df_3._binnings[0]) == 2*10 + 1 + 2
+    assert len(binned_df_3._weights) == 1
+
+def test_BinnedDataframe_numexpr_run_mc(binned_df_3, tmpdir, infile):
+    chunk = FakeBEEvent(infile, "mc")
+    collector = binned_df_3.collector()
+
+    binned_df_3.event(chunk)
+    dataset_readers_list = (("test_dataset", (binned_df_3,)),)
+    results = collector._prepare_output(dataset_readers_list)
+
+    bin_centers = pd.IntervalIndex(results.index.get_level_values('electron_pT')).mid
+    mean = np.sum((bin_centers[1:-1] * results['n'][1:-1]) / results['n'][1:-1].sum())
+    assert mean == pytest.approx(44.32584)


### PR DESCRIPTION
Fixes #46 

Adds ability to specify binning dimension and binning as expressions. Can be used to avoid creating a `fast_carpenter.Define` stage for simple transformations

e.g
```yaml
histogram:
    binning:
        - {in: MET_px**2 + MET_py**2, out: met,  bins: {low: 0, high: 10**2, nbins: 100}}
```