### PR TITLE
Added ability to save pandas dataframe as different file types

### DIFF
--- a/fast_carpenter/summary/binned_dataframe.py
+++ b/fast_carpenter/summary/binned_dataframe.py
@@ -19,18 +19,18 @@ class Collector():
 
         output = self._prepare_output(dataset_readers_list)
 
-        valid_ext={'xlsx':'excel','h5':'hdf','msg':'msgpack','dta':'stata','pkl':'pickle','p':'pickle'}
+        valid_ext = {'xlsx': 'excel', 'h5': 'hdf', 'msg': 'msgpack', 'dta': 'stata', 'pkl': 'pickle', 'p': 'pickle'}
         for file_type in self.file_format:
-            file_ext=file_type.pop('type', None)
-            save_func=file_ext.split('.')[1]
+            file_ext = file_type.pop('type', None)
+            save_func = file_ext.split('.')[1]
             if save_func in valid_ext:
-                save_func=valid_ext[save_func]
+                save_func = valid_ext[save_func]
             try:
-                getattr(output,"to_%s"%save_func)(self.filename+file_ext, **file_type)
+                getattr(output, "to_%s" % save_func)(self.filename+file_ext, **file_type)
             except AttributeError as err:
-                print("Incorrect file format: %s"%err)
+                print("Incorrect file format: %s" % err)
             except TypeError as err:
-                print("Incorrect args: %s"%err)
+                print("Incorrect args: %s" % err)
 
     def _prepare_output(self, dataset_readers_list):
         return combined_dataframes(dataset_readers_list,

--- a/fast_carpenter/summary/binned_dataframe.py
+++ b/fast_carpenter/summary/binned_dataframe.py
@@ -7,6 +7,7 @@ from . import binning_config as cfg
 
 
 class Collector():
+    valid_ext = {'xlsx': 'excel', 'h5': 'hdf', 'msg': 'msgpack', 'dta': 'stata', 'pkl': 'pickle', 'p': 'pickle'}
     def __init__(self, filename, dataset_col, binnings, file_format):
         self.filename = filename
         self.dataset_col = dataset_col
@@ -19,12 +20,11 @@ class Collector():
 
         output = self._prepare_output(dataset_readers_list)
 
-        valid_ext = {'xlsx': 'excel', 'h5': 'hdf', 'msg': 'msgpack', 'dta': 'stata', 'pkl': 'pickle', 'p': 'pickle'}
         for file_type in self.file_format:
             file_ext = file_type.pop('type', None)
             save_func = file_ext.split('.')[1]
-            if save_func in valid_ext:
-                save_func = valid_ext[save_func]
+            if save_func in Collector.valid_ext:
+                save_func = Collector.valid_ext[save_func]
             try:
                 getattr(output, "to_%s" % save_func)(self.filename+file_ext, **file_type)
             except AttributeError as err:
@@ -129,7 +129,11 @@ class BinnedDataframe():
         variables, or a dictionary where the values are variables in the data and
         keys are the column names that these weights should be called in the
         output tables.
-      file_format (str or list[str], dict[str, str]): X
+      file_format (str or list[str], dict[str, str]): determines the file format to 
+        use to save the binned dataframe to disk.  Should be either a) a string with 
+        the file format, b) a dict containing the keyword `type` to give the file 
+        format and then all other keyword-argument pairs are passed on to the 
+        corresponding pandas function, or c) a list of values matching a) or b).
       dataset_col (bool): adds an extra binning column with the name for each dataset.
       pad_missing (bool): If ``False``, any bins that don't contain data are
         excluded from the stored dataframe.  Leaving this ``False`` can save

--- a/fast_carpenter/summary/binned_dataframe.py
+++ b/fast_carpenter/summary/binned_dataframe.py
@@ -8,6 +8,7 @@ from . import binning_config as cfg
 
 class Collector():
     valid_ext = {'xlsx': 'excel', 'h5': 'hdf', 'msg': 'msgpack', 'dta': 'stata', 'pkl': 'pickle', 'p': 'pickle'}
+
     def __init__(self, filename, dataset_col, binnings, file_format):
         self.filename = filename
         self.dataset_col = dataset_col
@@ -20,13 +21,13 @@ class Collector():
 
         output = self._prepare_output(dataset_readers_list)
 
-        for file_type in self.file_format:
-            file_ext = file_type.pop('type', None)
+        for file_dict in self.file_format:
+            file_ext = file_dict.pop('extension', None)
             save_func = file_ext.split('.')[1]
             if save_func in Collector.valid_ext:
                 save_func = Collector.valid_ext[save_func]
             try:
-                getattr(output, "to_%s" % save_func)(self.filename+file_ext, **file_type)
+                getattr(output, "to_%s" % save_func)(self.filename+file_ext, **file_dict)
             except AttributeError as err:
                 print("Incorrect file format: %s" % err)
             except TypeError as err:
@@ -129,10 +130,10 @@ class BinnedDataframe():
         variables, or a dictionary where the values are variables in the data and
         keys are the column names that these weights should be called in the
         output tables.
-      file_format (str or list[str], dict[str, str]): determines the file format to 
-        use to save the binned dataframe to disk.  Should be either a) a string with 
-        the file format, b) a dict containing the keyword `type` to give the file 
-        format and then all other keyword-argument pairs are passed on to the 
+      file_format (str or list[str], dict[str, str]): determines the file format to
+        use to save the binned dataframe to disk.  Should be either a) a string with
+        the file format, b) a dict containing the keyword `extension` to give the file
+        format and then all other keyword-argument pairs are passed on to the
         corresponding pandas function, or c) a list of values matching a) or b).
       dataset_col (bool): adds an extra binning column with the name for each dataset.
       pad_missing (bool): If ``False``, any bins that don't contain data are

--- a/fast_carpenter/summary/binned_dataframe.py
+++ b/fast_carpenter/summary/binned_dataframe.py
@@ -29,6 +29,8 @@ class Collector():
                 getattr(output,"to_%s"%save_func)(self.filename+file_ext, **file_type)
             except AttributeError as err:
                 print("Incorrect file format: %s"%err)
+            except TypeError as err:
+                print("Incorrect args: %s"%err)
 
     def _prepare_output(self, dataset_readers_list):
         return combined_dataframes(dataset_readers_list,

--- a/fast_carpenter/summary/binning_config.py
+++ b/fast_carpenter/summary/binning_config.py
@@ -92,12 +92,15 @@ def create_weights(stage_name, weights):
 
 def create_file_format(stage_name, file_format):
     if file_format is None:
-        return [{'type': '.csv', 'float_format': '%.17g'}]
+        return [{'extension': '.csv', 'float_format': '%.17g'}]
     if isinstance(file_format, list):
-        file_format = [file_type if isinstance(file_type, dict) else {'type': file_type} for file_type in file_format]
+        file_format = [file_dict
+                       if isinstance(file_dict, dict)
+                       else {'extension': file_dict}
+                       for file_dict in file_format]
     elif isinstance(file_format, dict):
         file_format = [file_format]
     else:
         # else we've got a single, scalar value
-        file_format = [{'type': file_format}]
+        file_format = [{'extension': file_format}]
     return file_format

--- a/fast_carpenter/summary/binning_config.py
+++ b/fast_carpenter/summary/binning_config.py
@@ -89,9 +89,10 @@ def create_weights(stage_name, weights):
         weights = {weights: weights}
     return weights
 
-def create_file_format(stage_name,file_format):
+
+def create_file_format(stage_name, file_format):
     if file_format is None:
-        return [{'type':'.csv','float_format':'%.17g'}]
+        return [{'type': '.csv', 'float_format': '%.17g'}]
     if isinstance(file_format, list):
         file_format = [file_type if isinstance(file_type, dict) else {'type': file_type} for file_type in file_format]
     elif isinstance(file_format, dict):

--- a/fast_carpenter/summary/binning_config.py
+++ b/fast_carpenter/summary/binning_config.py
@@ -88,3 +88,15 @@ def create_weights(stage_name, weights):
         # else we've got a single, scalar value
         weights = {weights: weights}
     return weights
+
+def create_file_format(stage_name,file_format):
+    if file_format is None:
+        return [{'type':'.csv','float_format':'%.17g'}]
+    if isinstance(file_format, list):
+        file_format = [file_type if isinstance(file_type, dict) else {'type': file_type} for file_type in file_format]
+    elif isinstance(file_format, dict):
+        file_format = [file_format]
+    else:
+        # else we've got a single, scalar value
+        file_format = [{'type': file_format}]
+    return file_format

--- a/tests/summary/dummy_binning_descriptions.py
+++ b/tests/summary/dummy_binning_descriptions.py
@@ -13,3 +13,12 @@ weight_list = ["EventWeight"]
 
 
 weight_dict = dict(weighted="EventWeight")
+
+
+file_format_list = [dict(type=".pkl.compress", compression="gzip"), ".csv"]
+
+
+file_format_dict = dict(type=".h5", key="df")
+
+
+file_format_scalar = ".csv"

--- a/tests/summary/dummy_binning_descriptions.py
+++ b/tests/summary/dummy_binning_descriptions.py
@@ -15,10 +15,10 @@ weight_list = ["EventWeight"]
 weight_dict = dict(weighted="EventWeight")
 
 
-file_format_list = [dict(type=".pkl.compress", compression="gzip"), ".csv"]
+file_format_list = [dict(extension=".pkl.compress", compression="gzip"), ".csv"]
 
 
-file_format_dict = dict(type=".h5", key="df")
+file_format_dict = dict(extension=".h5", key="df")
 
 
 file_format_scalar = ".csv"

--- a/tests/summary/test_binning_config.py
+++ b/tests/summary/test_binning_config.py
@@ -56,3 +56,35 @@ def test_create_weights_dict():
     weights = mgr.create_weights(name, binning.weight_dict)
     assert len(weights) == 1
     assert weights["weighted"] == "EventWeight"
+
+
+def test_create_file_format_none():
+    name = "test_create_file_format_none"
+    file_format = mgr.create_file_format(name, None)
+    assert len(file_format) == 1
+    assert file_format[0]["type"] == ".csv"
+    assert file_format[0]["float_format"] == "%.17g"
+
+
+def test_create_file_format_list():
+    name = "test_create_file_format_list"
+    file_format = mgr.create_file_format(name, binning.file_format_list)
+    assert len(file_format) == 2
+    assert file_format[0]["type"] == ".pkl.compress"
+    assert file_format[0]["compression"] == "gzip"
+    assert file_format[1]["type"] == ".csv"
+
+
+def test_create_file_format_dict():
+    name = "test_create_file_format_dict"
+    file_format = mgr.create_file_format(name, binning.file_format_dict)
+    assert len(file_format) == 1
+    assert file_format[0]["type"] == ".h5"
+    assert file_format[0]["key"] == "df"
+
+
+def test_create_file_format_scalar():
+    name = "test_create_file_format_scalar"
+    file_format = mgr.create_file_format(name, binning.file_format_scalar)
+    assert len(file_format) == 1
+    assert file_format[0]["type"] == ".csv"

--- a/tests/summary/test_binning_config.py
+++ b/tests/summary/test_binning_config.py
@@ -62,7 +62,7 @@ def test_create_file_format_none():
     name = "test_create_file_format_none"
     file_format = mgr.create_file_format(name, None)
     assert len(file_format) == 1
-    assert file_format[0]["type"] == ".csv"
+    assert file_format[0]["extension"] == ".csv"
     assert file_format[0]["float_format"] == "%.17g"
 
 
@@ -70,16 +70,16 @@ def test_create_file_format_list():
     name = "test_create_file_format_list"
     file_format = mgr.create_file_format(name, binning.file_format_list)
     assert len(file_format) == 2
-    assert file_format[0]["type"] == ".pkl.compress"
+    assert file_format[0]["extension"] == ".pkl.compress"
     assert file_format[0]["compression"] == "gzip"
-    assert file_format[1]["type"] == ".csv"
+    assert file_format[1]["extension"] == ".csv"
 
 
 def test_create_file_format_dict():
     name = "test_create_file_format_dict"
     file_format = mgr.create_file_format(name, binning.file_format_dict)
     assert len(file_format) == 1
-    assert file_format[0]["type"] == ".h5"
+    assert file_format[0]["extension"] == ".h5"
     assert file_format[0]["key"] == "df"
 
 
@@ -87,4 +87,4 @@ def test_create_file_format_scalar():
     name = "test_create_file_format_scalar"
     file_format = mgr.create_file_format(name, binning.file_format_scalar)
     assert len(file_format) == 1
-    assert file_format[0]["type"] == ".csv"
+    assert file_format[0]["extension"] == ".csv"


### PR DESCRIPTION
`fast_carpenter` can now save the output pandas data frame in multiple different file types at once. I tested the default case where `file_format` is not included in the users yaml config and `fast_carpenter` produced the normal `.csv` file. I tested the yaml code below:
```yaml
  file_format:
    - {type: '.csv', float_format: '%.17g'}
    - {type: ".pkl.compress", compression: "gzip"}
    - type: '.h5'
      key: df
```
and it produced 3 different files correctly. I also tested this case:
```yaml
file_format: {type: '.csv', float_format: '%.17g'}
```
and it worked fine (this is the default if the user doesn't specify `file_format`. I also tested this:
```yaml
file_format: '.p'
```
and it generated the pickle file fine.
If this merges correctly then this closes #53 