### PR TITLE
Fix problem when similar branch names exist

### DIFF
--- a/fast_carpenter/summary/binned_dataframe.py
+++ b/fast_carpenter/summary/binned_dataframe.py
@@ -2,6 +2,7 @@
 Summarize the data by producing binned and possibly weighted counts of the data.
 """
 import os
+import re
 import pandas as pd
 from . import binning_config as cfg
 
@@ -156,6 +157,7 @@ class BinnedDataframe():
         self.out_dir = out_dir
         ins, outs, binnings = cfg.create_binning_list(self.name, binning)
         self._bin_dims = ins
+        self.potential_inputs = set(sum((re.findall(r"\w+", dim) for dim in self._bin_dims), []))
         self._out_bin_dims = outs
         self._binnings = binnings
         self._dataset_col = dataset_col
@@ -177,8 +179,7 @@ class BinnedDataframe():
         return Collector(outfilename, self._dataset_col, binnings=binnings, file_format=self._file_format)
 
     def event(self, chunk):
-
-        all_inputs = [key for key in chunk.tree.keys() if any(key.decode() in dim for dim in self._bin_dims)]
+        all_inputs = [key for key in chunk.tree.keys() if key.decode() in self.potential_inputs]
         if chunk.config.dataset.eventtype == "mc":
             weights = list(self._weights.values())
             all_inputs += weights

--- a/fast_carpenter/version.py
+++ b/fast_carpenter/version.py
@@ -12,5 +12,5 @@ def split_version(version):
     return tuple(result)
 
 
-__version__ = '0.12.0'
+__version__ = '0.13.0'
 version_info = split_version(__version__) # noqa

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.12.0-rc1
+current_version = 0.13.0
 commit = True
 tag = False
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,6 +29,13 @@ def wrapped_tree(infile, event_range):
     return tree
 
 
+@pytest.fixture
+def full_wrapped_tree(infile, full_event_range):
+    import fast_carpenter.tree_wrapper as tree_w
+    tree = tree_w.WrappedTree(infile, full_event_range)
+    return tree
+
+
 class Namespace():
     def __init__(self, **kwargs):
         self.__dict__.update(kwargs)

--- a/tests/summary/test_binned_dataframe.py
+++ b/tests/summary/test_binned_dataframe.py
@@ -161,3 +161,18 @@ def test_BinnedDataframe_numexpr_run_mc(binned_df_3, tmpdir, infile):
     bin_centers = pd.IntervalIndex(results.index.get_level_values('electron_pT')).mid
     mean = np.sum((bin_centers[1:-1] * results['n'][1:-1]) / results['n'][1:-1].sum())
     assert mean == pytest.approx(44.32584)
+
+
+def test_BinnedDataframe_numexpr_similar_branch(binned_df_3, tmpdir, full_wrapped_tree):
+    chunk = FakeBEEvent(full_wrapped_tree, "mc")
+    new_var = 2 * chunk.tree.array("Electron_Px")
+    chunk.tree.new_variable("tron_Px", new_var)
+    collector = binned_df_3.collector()
+
+    binned_df_3.event(chunk)
+    dataset_readers_list = (("test_dataset", (binned_df_3,)),)
+    results = collector._prepare_output(dataset_readers_list)
+
+    bin_centers = pd.IntervalIndex(results.index.get_level_values('electron_pT')).mid
+    mean = np.sum((bin_centers[1:-1] * results['n'][1:-1]) / results['n'][1:-1].sum())
+    assert mean == pytest.approx(44.32584)


### PR DESCRIPTION
Since #46 there's been an issue that if two variables exist where the second's name is also a substring of the first, and if someone tries to make a binned dataframe using the first, the system crashes.  The problem arose from how we selected which branches need to be considered for input to the binning stage.

This PR: 
* Solves the above problem
* Bumps the minor version
* Adds more unit tests

It may also be related to #51, @rob-tay.