### PR TITLE
Make array(s) methods consistent for masked uproot trees

### DIFF
--- a/fast_carpenter/masked_tree.py
+++ b/fast_carpenter/masked_tree.py
@@ -34,20 +34,38 @@ class MaskedUprootTree(object):
     def pandas(self):
         return MaskedUprootTree.PandasWrap(self)
 
-    def masked_array(self, *args, **kwargs):
+    def unmasked_array(self, *args, **kwargs):
+      return self.tree.array(*args, **kwargs)
+
+    def unmasked_arrays(self, *args, **kwargs):
+      return self.tree.arrays(*args, **kwargs)
+
+    def array(self, *args, **kwargs):
       array = self.tree.array(*args, **kwargs)
+      if self._mask is None:
+        return array
       return array[self._mask]
 
-    def masked_arrays(self, *args, **kwargs):
+    def arrays(self, *args, **kwargs):
       arrays = self.tree.arrays(*args, **kwargs)
+      if self._mask is None:
+          return arrays
       if isinstance(arrays, dict):
-        return {k: v[self._mask] for k, v in arrays.items()}
+          return {k: v[self._mask] for k, v in arrays.items()}
       if isinstance(arrays, tuple):
-        return tuple([v[self._mask] for v in arrays])
+          return tuple([v[self._mask] for v in arrays])
       if isinstance(arrays, list):
-        return [v[self._mask] for v in arrays]
+          return [v[self._mask] for v in arrays]
       if isinstance(arrays, pd.DataFrame):
-        return mask_df(arrays, self._mask, self.event_ranger.start_entry)
+          return mask_df(arrays, self._mask, self.event_ranger.start_entry)
+      if isinstance(arrays, np.ndarray):
+          if arrays.ndim == 1:
+              return arrays[self._mask]
+          if arrays.ndim == 2:
+              if arrays.shape[1] == len(self):
+                  return arrays[:, self._mask]
+          msg = "Unexpected numpy array for mask, shape:%s, mask length: %s"
+          raise NotImplementedError(msg % (arrays.shape, len(self)))
       return arrays[self._mask]
 
     @property

--- a/fast_carpenter/masked_tree.py
+++ b/fast_carpenter/masked_tree.py
@@ -34,6 +34,22 @@ class MaskedUprootTree(object):
     def pandas(self):
         return MaskedUprootTree.PandasWrap(self)
 
+    def masked_array(self, *args, **kwargs):
+      array = self.tree.array(*args, **kwargs)
+      return array[self._mask]
+
+    def masked_arrays(self, *args, **kwargs):
+      arrays = self.tree.arrays(*args, **kwargs)
+      if isinstance(arrays, dict):
+        return {k: v[self._mask] for k, v in arrays.items()}
+      if isinstance(arrays, tuple):
+        return tuple([v[self._mask] for v in arrays])
+      if isinstance(arrays, list):
+        return [v[self._mask] for v in arrays]
+      if isinstance(arrays, pd.DataFrame):
+        return mask_df(arrays, self._mask, self.event_ranger.start_entry)
+      return arrays[self._mask]
+
     @property
     def mask(self):
         return self._mask

--- a/fast_carpenter/masked_tree.py
+++ b/fast_carpenter/masked_tree.py
@@ -35,38 +35,38 @@ class MaskedUprootTree(object):
         return MaskedUprootTree.PandasWrap(self)
 
     def unmasked_array(self, *args, **kwargs):
-      return self.tree.array(*args, **kwargs)
+        return self.tree.array(*args, **kwargs)
 
     def unmasked_arrays(self, *args, **kwargs):
-      return self.tree.arrays(*args, **kwargs)
+        return self.tree.arrays(*args, **kwargs)
 
     def array(self, *args, **kwargs):
-      array = self.tree.array(*args, **kwargs)
-      if self._mask is None:
-        return array
-      return array[self._mask]
+        array = self.tree.array(*args, **kwargs)
+        if self._mask is None:
+            return array
+        return array[self._mask]
 
     def arrays(self, *args, **kwargs):
-      arrays = self.tree.arrays(*args, **kwargs)
-      if self._mask is None:
-          return arrays
-      if isinstance(arrays, dict):
-          return {k: v[self._mask] for k, v in arrays.items()}
-      if isinstance(arrays, tuple):
-          return tuple([v[self._mask] for v in arrays])
-      if isinstance(arrays, list):
-          return [v[self._mask] for v in arrays]
-      if isinstance(arrays, pd.DataFrame):
-          return mask_df(arrays, self._mask, self.event_ranger.start_entry)
-      if isinstance(arrays, np.ndarray):
-          if arrays.ndim == 1:
-              return arrays[self._mask]
-          if arrays.ndim == 2:
-              if arrays.shape[1] == len(self):
-                  return arrays[:, self._mask]
-          msg = "Unexpected numpy array for mask, shape:%s, mask length: %s"
-          raise NotImplementedError(msg % (arrays.shape, len(self)))
-      return arrays[self._mask]
+        arrays = self.tree.arrays(*args, **kwargs)
+        if self._mask is None:
+            return arrays
+        if isinstance(arrays, dict):
+            return {k: v[self._mask] for k, v in arrays.items()}
+        if isinstance(arrays, tuple):
+            return tuple([v[self._mask] for v in arrays])
+        if isinstance(arrays, list):
+            return [v[self._mask] for v in arrays]
+        if isinstance(arrays, pd.DataFrame):
+            return mask_df(arrays, self._mask, self.event_ranger.start_entry)
+        if isinstance(arrays, np.ndarray):
+            if arrays.ndim == 1:
+                return arrays[self._mask]
+            if arrays.ndim == 2:
+                if arrays.shape[1] == len(self):
+                    return arrays[:, self._mask]
+            msg = "Unexpected numpy array for mask, shape:%s, mask length: %s"
+            raise NotImplementedError(msg % (arrays.shape, len(self)))
+        return arrays[self._mask]
 
     @property
     def mask(self):

--- a/fast_carpenter/masked_tree.py
+++ b/fast_carpenter/masked_tree.py
@@ -62,7 +62,7 @@ class MaskedUprootTree(object):
             if arrays.ndim == 1:
                 return arrays[self._mask]
             if arrays.ndim == 2:
-                if arrays.shape[1] == len(self):
+                if arrays.shape[1] == len(self.tree):
                     return arrays[:, self._mask]
             msg = "Unexpected numpy array for mask, shape:%s, mask length: %s"
             raise NotImplementedError(msg % (arrays.shape, len(self)))

--- a/tests/selection/test_stage.py
+++ b/tests/selection/test_stage.py
@@ -147,8 +147,4 @@ def test_sequential_stages(cutflow_1, select_2, infile, full_event_range, tmpdir
     cutflow_1.event(chunk)
     cutflow_2.event(chunk)
 
-    assert len(chunk.tree) == 289
-
-    collector = cutflow_1.collector()
-    assert collector.filename == str(tmpdir / "cuts_cutflow_1-NElectron.csv")
-
+    assert len(chunk.tree) == 2

--- a/tests/selection/test_stage.py
+++ b/tests/selection/test_stage.py
@@ -139,3 +139,16 @@ def test_cutflow_2_collect(select_2, tmpdir, infile, full_event_range, multi_chu
     assert output.loc[("test_mc", 0, "All"), ("totals_incl", "unweighted")] == 4580 * 2
     assert output.loc[("test_data", 1, "NMuon > 1"), ("passed_only_cut", "unweighted")] == 289 * 2
     assert output.loc[("test_mc", 1, "NMuon > 1"), ("passed_only_cut", "unweighted")] == 289 * 2
+
+
+def test_sequential_stages(cutflow_1, select_2, infile, full_event_range, tmpdir):
+    cutflow_2 = stage.CutFlow("cutflow_2", str(tmpdir), selection=select_2, weights="EventWeight")
+    chunk = FakeBEEvent(MaskedUprootTree(infile, event_ranger=full_event_range), "data")
+    cutflow_1.event(chunk)
+    cutflow_2.event(chunk)
+
+    assert len(chunk.tree) == 289
+
+    collector = cutflow_1.collector()
+    assert collector.filename == str(tmpdir / "cuts_cutflow_1-NElectron.csv")
+

--- a/tests/test_masked_tree.py
+++ b/tests/test_masked_tree.py
@@ -46,3 +46,29 @@ def test_w_mask_int(tree_w_mask_int, infile):
     assert len(tree_w_mask_int) == 25
     df = tree_w_mask_int.pandas.df("Muon_Px")
     assert len(df.index.unique(0)) == 25
+
+
+def test_masked_array(tree_w_mask_int, infile):
+    assert len(tree_w_mask_int) == 50
+    tree_w_mask_int.apply_mask(np.arange(0, len(tree_w_mask_int), 2))
+    assert len(tree_w_mask_int) == 25
+    array = tree_w_mask_int.masked_array("Muon_Px")
+    assert len(array) == 25
+
+
+def test_masked_arrays(tree_w_mask_int, infile):
+    assert len(tree_w_mask_int) == 50
+    tree_w_mask_int.apply_mask(np.arange(0, len(tree_w_mask_int), 2))
+    assert len(tree_w_mask_int) == 25
+
+    arrays = tree_w_mask_int.masked_arrays(["Muon_Px", "Muon_Py"], outputtype=dict)
+    assert isinstance(arrays, dict)
+    assert len(arrays) == 2
+    assert len(arrays["Muon_Py"]) == 25
+    assert len(arrays["Muon_Px"]) == 25
+
+    arrays = tree_w_mask_int.masked_arrays(["Muon_Px", "Muon_Py"], outputtype=tuple)
+    assert isinstance(arrays, tuple)
+    assert len(arrays) == 2
+    assert len(arrays[0]) == 25
+    assert len(arrays[1]) == 25

--- a/tests/test_masked_tree.py
+++ b/tests/test_masked_tree.py
@@ -65,8 +65,7 @@ def test_arrays(tree_w_mask_int, infile):
     arrays = tree_w_mask_int.arrays(["Muon_Px", "Muon_Py"], outputtype=dict)
     assert isinstance(arrays, dict)
     assert len(arrays) == 2
-    assert len(arrays["Muon_Py"]) == 25
-    assert len(arrays["Muon_Px"]) == 25
+    assert [len(v) for v in arrays.values()] == [25, 25]
 
     for outtype in [list, tuple]:
         arrays = tree_w_mask_int.arrays(["Muon_Px", "Muon_Py"], outputtype=outtype)

--- a/tests/test_masked_tree.py
+++ b/tests/test_masked_tree.py
@@ -48,26 +48,26 @@ def test_w_mask_int(tree_w_mask_int, infile):
     assert len(df.index.unique(0)) == 25
 
 
-def test_masked_array(tree_w_mask_int, infile):
+def test_array(tree_w_mask_int, infile):
     assert len(tree_w_mask_int) == 50
     tree_w_mask_int.apply_mask(np.arange(0, len(tree_w_mask_int), 2))
     assert len(tree_w_mask_int) == 25
-    array = tree_w_mask_int.masked_array("Muon_Px")
+    array = tree_w_mask_int.array("Muon_Px")
     assert len(array) == 25
 
 
-def test_masked_arrays(tree_w_mask_int, infile):
+def test_arrays(tree_w_mask_int, infile):
     assert len(tree_w_mask_int) == 50
     tree_w_mask_int.apply_mask(np.arange(0, len(tree_w_mask_int), 2))
     assert len(tree_w_mask_int) == 25
 
-    arrays = tree_w_mask_int.masked_arrays(["Muon_Px", "Muon_Py"], outputtype=dict)
+    arrays = tree_w_mask_int.arrays(["Muon_Px", "Muon_Py"], outputtype=dict)
     assert isinstance(arrays, dict)
     assert len(arrays) == 2
     assert len(arrays["Muon_Py"]) == 25
     assert len(arrays["Muon_Px"]) == 25
 
-    arrays = tree_w_mask_int.masked_arrays(["Muon_Px", "Muon_Py"], outputtype=tuple)
+    arrays = tree_w_mask_int.arrays(["Muon_Px", "Muon_Py"], outputtype=tuple)
     assert isinstance(arrays, tuple)
     assert len(arrays) == 2
     assert len(arrays[0]) == 25

--- a/tests/test_masked_tree.py
+++ b/tests/test_masked_tree.py
@@ -90,4 +90,3 @@ def test_arrays(tree_w_mask_int, infile):
     assert isinstance(arrays, pd.DataFrame)
     assert len(arrays) == 25
     assert len(arrays.columns) == 2
-

--- a/tests/test_masked_tree.py
+++ b/tests/test_masked_tree.py
@@ -1,6 +1,7 @@
 from __future__ import division
 import pytest
 import numpy as np
+import pandas as pd
 import fast_carpenter.masked_tree as m_tree
 
 
@@ -67,8 +68,26 @@ def test_arrays(tree_w_mask_int, infile):
     assert len(arrays["Muon_Py"]) == 25
     assert len(arrays["Muon_Px"]) == 25
 
-    arrays = tree_w_mask_int.arrays(["Muon_Px", "Muon_Py"], outputtype=tuple)
-    assert isinstance(arrays, tuple)
-    assert len(arrays) == 2
-    assert len(arrays[0]) == 25
-    assert len(arrays[1]) == 25
+    for outtype in [list, tuple]:
+        arrays = tree_w_mask_int.arrays(["Muon_Px", "Muon_Py"], outputtype=outtype)
+        assert isinstance(arrays, outtype)
+        assert len(arrays) == 2
+        assert len(arrays[0]) == 25
+        assert len(arrays[1]) == 25
+
+    arrays = tree_w_mask_int.arrays(["Muon_Px", "Muon_Py"],
+                                    outputtype=lambda *args: np.array(args))
+    assert isinstance(arrays, np.ndarray)
+    assert arrays.shape == (2, 25)
+
+    arrays = tree_w_mask_int.arrays(["Muon_Px"],
+                                    outputtype=lambda *args: np.array(args))
+    assert isinstance(arrays, np.ndarray)
+    assert arrays.shape == (1, 25)
+
+    arrays = tree_w_mask_int.arrays(["Muon_Px", "Muon_Py"],
+                                    outputtype=pd.DataFrame)
+    assert isinstance(arrays, pd.DataFrame)
+    assert len(arrays) == 25
+    assert len(arrays.columns) == 2
+


### PR DESCRIPTION
It turned out issue #58 was actually caused by issue #25.  This PR fixes both of these.
It overrides the `array` and `arrays` methods of `uproot.tree` by providing `MaskedUprootTree` with corresponding methods.  It also adds unit tests for these new methods.

This is potentially a large change in that some analysis configurations may now break if they relied on this inconsistent behaviour.