### PR TITLE
Fix itervalues for overwritten branches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
-## [0.13.2] - 2019-08-18
+## [0.13.2] - 2019-08-19
 ### Changed
 - Protect against overwriting branches and add tests, pull request #66 [@benkrikler](https://github.com/benkrikler)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.13.2] - 2019-08-18
 ### Changed
-- Fix itervalues for overwritten branches, pull request #66 [@benkrikler](https://github.com/benkrikler)
+- Protect against overwriting branches and add tests, pull request #66 [@benkrikler](https://github.com/benkrikler)
 
 ## [0.13.1] - 2019-08-05
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+## [0.13.2] - 2019-08-18
+### Changed
+- Fix itervalues for overwritten branches, pull request #66 [@benkrikler](https://github.com/benkrikler)
+
 ## [0.13.1] - 2019-08-05
 ### Added
 - Adds support for masking variables in their definition, issue #59 [@benkrikler](https://github.com/benkrikler)

--- a/fast_carpenter/tree_wrapper.py
+++ b/fast_carpenter/tree_wrapper.py
@@ -46,7 +46,8 @@ class WrappedTree(object):
         for array in self.extras.values():
             yield array
         for vals in self.tree.old_itervalues(*args, **kwargs):
-            yield vals
+            if vals.name not in self.extras:
+                yield vals
 
     def arrays(self, *args, **kwargs):
         self.update_array_args(kwargs)

--- a/fast_carpenter/tree_wrapper.py
+++ b/fast_carpenter/tree_wrapper.py
@@ -46,8 +46,7 @@ class WrappedTree(object):
         for array in self.extras.values():
             yield array
         for vals in self.tree.old_itervalues(*args, **kwargs):
-            if vals.name not in self.extras:
-                yield vals
+            yield vals
 
     def arrays(self, *args, **kwargs):
         self.update_array_args(kwargs)
@@ -105,6 +104,9 @@ class WrappedTree(object):
             return len(self._values)
 
     def new_variable(self, name, value):
+        if name in self:
+            msg = "Trying to overwrite existing variable: '%s'"
+            raise ValueError(msg % name)
         if len(value) != len(self):
             msg = "New array %s does not have the right length: %d not %d"
             raise ValueError(msg % (name, len(value), len(self)))

--- a/fast_carpenter/version.py
+++ b/fast_carpenter/version.py
@@ -12,5 +12,5 @@ def split_version(version):
     return tuple(result)
 
 
-__version__ = '0.13.1'
+__version__ = '0.13.2'
 version_info = split_version(__version__) # noqa

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.13.1
+current_version = 0.13.2
 commit = True
 tag = False
 

--- a/tests/test_tree_wrapper.py
+++ b/tests/test_tree_wrapper.py
@@ -18,5 +18,4 @@ def test_overwrite(wrapped_tree):
     with pytest.raises(ValueError) as err:
         wrapped_tree.new_variable("Muon_Px", muon_px / muon_px)
     assert "Muon_Px" in str(err)
-    retrieve_momentum = wrapped_tree.array("Muon_Px")
     assert len(wrapped_tree.keys(filtername=lambda x: x.decode() == "Muon_Px")) == 1

--- a/tests/test_tree_wrapper.py
+++ b/tests/test_tree_wrapper.py
@@ -1,3 +1,4 @@
+import pytest
 import numpy as np
 
 
@@ -10,3 +11,12 @@ def test_add_retrieve(wrapped_tree):
     wrapped_tree.new_variable("Muon_momentum", muon_momentum)
     retrieve_momentum = wrapped_tree.array("Muon_momentum")
     assert (retrieve_momentum == muon_momentum).flatten().all()
+
+
+def test_overwrite(wrapped_tree):
+    muon_px = wrapped_tree.array("Muon_Px")
+    with pytest.raises(ValueError) as err:
+        wrapped_tree.new_variable("Muon_Px", muon_px / muon_px)
+    assert "Muon_Px" in str(err)
+    retrieve_momentum = wrapped_tree.array("Muon_Px")
+    assert len(wrapped_tree.keys(filtername=lambda x: x == "Muon_Px")) == 1

--- a/tests/test_tree_wrapper.py
+++ b/tests/test_tree_wrapper.py
@@ -19,4 +19,4 @@ def test_overwrite(wrapped_tree):
         wrapped_tree.new_variable("Muon_Px", muon_px / muon_px)
     assert "Muon_Px" in str(err)
     retrieve_momentum = wrapped_tree.array("Muon_Px")
-    assert len(wrapped_tree.keys(filtername=lambda x: x == "Muon_Px")) == 1
+    assert len(wrapped_tree.keys(filtername=lambda x: x.decode() == "Muon_Px")) == 1


### PR DESCRIPTION
The itervalues method of `tree_wrapper.WrappedTree` returned all branches in the original tree and all newly defined values.  If a variable with the same name was added to the tree, this could cause problems.  Now we only return the overwritten branch instead.