### PR TITLE
Fix interpretation of user-defined JaggedArrays 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+## [0.13.4] - 2019-09-21
+### Changed
+- Fixed interpretation of user-defined variables for uproot, issue #67, PR #71 [@benkrikler](https://github.com/benkrikler)
+
 ## [0.13.3] - 2019-09-12
 ### Changed
 - Add changes to support uproot 3.9.1 and greater, issue #68 [@benkrikler](https://github.com/benkrikler)

--- a/fast_carpenter/tree_wrapper.py
+++ b/fast_carpenter/tree_wrapper.py
@@ -7,6 +7,7 @@ minimal coding on my side...
 """
 import uproot
 from uproot.interp.jagged import asjagged
+from uproot.interp.numerical import asdtype
 import copy
 import awkward
 
@@ -19,7 +20,7 @@ def wrapped_interpret(branch, *args, **kwargs):
 
     if isinstance(branch, WrappedTree.FakeBranch):
         if isinstance(branch._values, awkward.JaggedArray):
-            return asjagged(branch._values.content)
+            return asjagged(asdtype(branch._values.content.dtype.fields))
         else:
             return branch._values
 

--- a/fast_carpenter/version.py
+++ b/fast_carpenter/version.py
@@ -12,5 +12,5 @@ def split_version(version):
     return tuple(result)
 
 
-__version__ = '0.13.3'
+__version__ = '0.13.4'
 version_info = split_version(__version__) # noqa

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.13.3
+current_version = 0.13.4
 commit = True
 tag = False
 


### PR DESCRIPTION
User defined jagged arrays were not correctly interpreted for uproot by the WrappedTree class.
This was a problem when converting these variables to a pandas dataframe, giving rise to issue #67, which this fixes.