### PR TITLE
Allow collectors to return data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-
+- Existing collectors may now return their results within python, in addition to writing them to disk PR #90 [@lgray](https://github.com/lgray). 
+   - This behavior can, at present, only be controlled within python, and is meant for exposing certain aspects of FAST-carpenter plumbing to [coffea](https://github.com/CoffeaTeam/coffea).
 ### Changed
 - Pin atuproot to v0.1.13, PR #91
 

--- a/fast_carpenter/selection/stage.py
+++ b/fast_carpenter/selection/stage.py
@@ -33,12 +33,20 @@ class Collector():
         self.filename = filename
         self.keep_unique_id = keep_unique_id
 
-    def collect(self, dataset_readers_list):
+    def collect(self, dataset_readers_list, doReturn=False, writeFiles=True):
         if len(dataset_readers_list) == 0:
-            return None
+            if doReturn:
+                return pd.DataFrame()
+            else:
+                return None
 
         output = self._prepare_output(dataset_readers_list)
-        output.to_csv(self.filename, float_format="%.17g")
+        
+        if writeFiles:
+            output.to_csv(self.filename, float_format="%.17g")
+
+        if doReturn:
+            return output
 
     def _prepare_output(self, dataset_readers_list):
         dataset_readers_list = [(d, [r.selection for r in readers])

--- a/fast_carpenter/selection/stage.py
+++ b/fast_carpenter/selection/stage.py
@@ -41,7 +41,7 @@ class Collector():
                 return None
 
         output = self._prepare_output(dataset_readers_list)
-        
+
         if writeFiles:
             output.to_csv(self.filename, float_format="%.17g")
 

--- a/fast_carpenter/selection/stage.py
+++ b/fast_carpenter/selection/stage.py
@@ -33,7 +33,7 @@ class Collector():
         self.filename = filename
         self.keep_unique_id = keep_unique_id
 
-    def collect(self, dataset_readers_list, doReturn=False, writeFiles=True):
+    def collect(self, dataset_readers_list, doReturn=True, writeFiles=True):
         if len(dataset_readers_list) == 0:
             if doReturn:
                 return pd.DataFrame()

--- a/fast_carpenter/summary/binned_dataframe.py
+++ b/fast_carpenter/summary/binned_dataframe.py
@@ -18,7 +18,7 @@ class Collector():
         self.binnings = binnings
         self.file_format = file_format
 
-    def collect(self, dataset_readers_list, doReturn=False, writeFiles=True):
+    def collect(self, dataset_readers_list, doReturn=True, writeFiles=True):
         if len(dataset_readers_list) == 0:
             if doReturn:
                 return pd.DataFrame()

--- a/fast_carpenter/summary/binned_dataframe.py
+++ b/fast_carpenter/summary/binned_dataframe.py
@@ -18,23 +18,30 @@ class Collector():
         self.binnings = binnings
         self.file_format = file_format
 
-    def collect(self, dataset_readers_list):
+    def collect(self, dataset_readers_list, doReturn=False, writeFiles=True):
         if len(dataset_readers_list) == 0:
-            return
+            if doReturn:
+                return pd.DataFrame()
+            else:
+                return None
 
         output = self._prepare_output(dataset_readers_list)
 
-        for file_dict in self.file_format:
-            file_ext = file_dict.pop('extension', None)
-            save_func = file_ext.split('.')[1]
-            if save_func in Collector.valid_ext:
-                save_func = Collector.valid_ext[save_func]
-            try:
-                getattr(output, "to_%s" % save_func)(self.filename+file_ext, **file_dict)
-            except AttributeError as err:
-                print("Incorrect file format: %s" % err)
-            except TypeError as err:
-                print("Incorrect args: %s" % err)
+        if writeFiles:
+            for file_dict in self.file_format:
+                file_ext = file_dict.pop('extension', None)
+                save_func = file_ext.split('.')[1]
+                if save_func in Collector.valid_ext:
+                    save_func = Collector.valid_ext[save_func]
+                try:
+                    getattr(output, "to_%s" % save_func)(self.filename+file_ext, **file_dict)
+                except AttributeError as err:
+                    print("Incorrect file format: %s" % err)
+                except TypeError as err:
+                    print("Incorrect args: %s" % err)
+
+        if doReturn:
+            return output
 
     def _prepare_output(self, dataset_readers_list):
         return combined_dataframes(dataset_readers_list,

--- a/tests/selection/test_stage.py
+++ b/tests/selection/test_stage.py
@@ -140,6 +140,22 @@ def test_cutflow_2_collect(select_2, tmpdir, infile, full_event_range, multi_chu
     assert output.loc[("test_data", 1, "NMuon > 1"), ("passed_only_cut", "unweighted")] == 289 * 2
     assert output.loc[("test_mc", 1, "NMuon > 1"), ("passed_only_cut", "unweighted")] == 289 * 2
 
+    coll_out = collector.collect(dataset_readers_list, writeFiles=False)
+
+    assert len(coll_out) == 12
+    data = coll_out.xs("test_data", level="dataset", axis="rows")
+    data_weighted = data.xs("EventWeight", level=1, axis="columns")
+    data_unweighted = data.xs("unweighted", level=1, axis="columns")
+    assert all(data_weighted == data_unweighted)
+    mc = coll_out.xs("test_mc", level="dataset", axis="rows")
+    mc_unweighted = mc.xs("unweighted", level=1, axis="columns")
+    assert all(mc_unweighted == data_unweighted)
+    assert coll_out.loc[("test_data", 0, "All"), ("totals_incl", "unweighted")] == 4580 * 2
+    assert coll_out.loc[("test_data", 0, "All"), ("totals_incl", "EventWeight")] == 4580 * 2
+    assert coll_out.loc[("test_mc", 0, "All"), ("totals_incl", "unweighted")] == 4580 * 2
+    assert coll_out.loc[("test_data", 1, "NMuon > 1"), ("passed_only_cut", "unweighted")] == 289 * 2
+    assert coll_out.loc[("test_mc", 1, "NMuon > 1"), ("passed_only_cut", "unweighted")] == 289 * 2
+
 
 def test_sequential_stages(cutflow_1, select_2, infile, full_event_range, tmpdir):
     cutflow_2 = stage.CutFlow("cutflow_2", str(tmpdir), selection=select_2, weights="EventWeight")

--- a/tests/summary/test_binned_dataframe.py
+++ b/tests/summary/test_binned_dataframe.py
@@ -70,10 +70,10 @@ def test_BinnedDataframe_run_mc(binned_df_1, tmpdir, infile):
 
     coll_results = collector.collect(dataset_readers_list, writeFiles=False)
 
-    totals = results.sum()
+    totals = coll_results.sum()
     # Based on: events->Draw("Jet_Py", "", "goff")
     assert totals["n"] == 4616
-    
+
     # Based on:
     # events->Draw("EventWeight * (Jet_Py/Jet_Py)>>htemp", "", "goff")
     # htemp->GetMean() * htemp->GetEntries()

--- a/tests/summary/test_binned_dataframe.py
+++ b/tests/summary/test_binned_dataframe.py
@@ -68,6 +68,17 @@ def test_BinnedDataframe_run_mc(binned_df_1, tmpdir, infile):
     # htemp->GetMean() * htemp->GetEntries()
     assert totals["EventWeight:sumw"] == pytest.approx(231.91339)
 
+    coll_results = collector.collect(dataset_readers_list, writeFiles=False)
+
+    totals = results.sum()
+    # Based on: events->Draw("Jet_Py", "", "goff")
+    assert totals["n"] == 4616
+    
+    # Based on:
+    # events->Draw("EventWeight * (Jet_Py/Jet_Py)>>htemp", "", "goff")
+    # htemp->GetMean() * htemp->GetEntries()
+    assert totals["EventWeight:sumw"] == pytest.approx(231.91339)
+
 
 def test_BinnedDataframe_run_data(binned_df_2, tmpdir, infile):
     chunk = FakeBEEvent(infile, "data")


### PR DESCRIPTION
Add in defaulted options to collector.collect()
- one to return data in-memory
- one to control file writing

Both are defaulted to expected behavior in fast-carpenter.

This is towards #88.