### PR TITLE
Pin atuproot to a stable version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+
 ### Changed
-### Removed
+- Pin atuproot to v0.1.13, PR #91
 
 ## [0.14.3] - 2019-10-07
 ### Added

--- a/fast_carpenter/version.py
+++ b/fast_carpenter/version.py
@@ -12,5 +12,5 @@ def split_version(version):
     return tuple(result)
 
 
-__version__ = '0.14.3'
+__version__ = '0.14.4'
 version_info = split_version(__version__) # noqa

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.14.3
+current_version = 0.14.4
 commit = True
 tag = False
 

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ def get_version():
     return _globals["__version__"]
 
 
-requirements = ['atsge>=0.1.10', 'atuproot>=0.1.13', 'fast-flow', 'fast-curator', 'awkward',
+requirements = ['atsge>=0.1.10', 'atuproot==0.1.13', 'fast-flow', 'fast-curator', 'awkward',
                 'pandas', 'numpy', 'numba', 'numexpr', 'uproot>=3']
 repositories = []
 


### PR DESCRIPTION
This should fix the CI failures of #90 and those seen in the demo repo pipeline (e.g. https://gitlab.cern.ch/fast-hep/public/fast_cms_public_tutorial/-/jobs/5836339). 