### PR TITLE
Fix issue 89

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+- Fix bug in BinnedDataframe stage, issue #89, PR #93 [@benkrikler](httsp://github.com/benkrikler)
 - Pin atuproot to v0.1.13, PR #91
 
 ## [0.14.3] - 2019-10-07

--- a/fast_carpenter/summary/binned_dataframe.py
+++ b/fast_carpenter/summary/binned_dataframe.py
@@ -255,7 +255,7 @@ def _bin_values(data, dimensions, binnings, weights, out_dimensions=None, out_we
     return histogram
 
 
-def explode(df, fill_value=float("nan")):
+def explode(df):
     """
     Based on this answer:
     https://stackoverflow.com/questions/12680754/split-explode-pandas\
@@ -270,6 +270,7 @@ def explode(df, fill_value=float("nan")):
     idx_cols = df.columns.difference(lst_cols)
 
     # check all lists have same length
+    df2 = df.reset_index()
     lens = pd.DataFrame({col: df[col].str.len() for col in lst_cols})
     different_length = (lens.nunique(axis=1) > 1).any()
     if different_length:
@@ -281,12 +282,6 @@ def explode(df, fill_value=float("nan")):
     flattened = {col: sum(map(list, vals), []) for col, vals in flattened.items()}
     res = pd.DataFrame({col: np.repeat(df[col].values, lens) for col in idx_cols})
     res = res.assign(**flattened)
-
-    # append those rows that have empty lists
-    if (lens == 0).any():
-        # at least one list in cells is empty
-        res = (res.append(df.loc[lens == 0, idx_cols], sort=False)
-                  .fillna(fill_value))
 
     # Check that rows are fully "exploded"
     return explode(res)

--- a/fast_carpenter/summary/binned_dataframe.py
+++ b/fast_carpenter/summary/binned_dataframe.py
@@ -30,7 +30,7 @@ class Collector():
             if save_func in Collector.valid_ext:
                 save_func = Collector.valid_ext[save_func]
             try:
-                getattr(output, "to_%s" % save_func)(self.filename+file_ext, **file_dict)
+                getattr(output, "to_%s" % save_func)(self.filename + file_ext, **file_dict)
             except AttributeError as err:
                 print("Incorrect file format: %s" % err)
             except TypeError as err:
@@ -270,7 +270,6 @@ def explode(df):
     idx_cols = df.columns.difference(lst_cols)
 
     # check all lists have same length
-    df2 = df.reset_index()
     lens = pd.DataFrame({col: df[col].str.len() for col in lst_cols})
     different_length = (lens.nunique(axis=1) > 1).any()
     if different_length:

--- a/tests/summary/test_binned_dataframe.py
+++ b/tests/summary/test_binned_dataframe.py
@@ -204,6 +204,7 @@ def test_explode():
     exploded = bdf.explode(df)
     assert len(exploded) == 6
     assert all(df.B == 1)
+    assert not df.isnull().any().any()
 
     df["C"] = df.A.copy()
     exploded = bdf.explode(df)

--- a/tests/summary/test_binned_dataframe.py
+++ b/tests/summary/test_binned_dataframe.py
@@ -202,12 +202,12 @@ def test_BinnedDataframe_numexpr_similar_branch(binned_df_3, tmpdir, full_wrappe
 def test_explode():
     df = pd.DataFrame({'A': [[1, 2, 3], [9], [], [3, 4]], 'B': 1})
     exploded = bdf.explode(df)
-    assert len(exploded) == 7
+    assert len(exploded) == 6
     assert all(df.B == 1)
 
     df["C"] = df.A.copy()
     exploded = bdf.explode(df)
-    assert len(exploded) == 7
+    assert len(exploded) == 6
     assert all(df.B == 1)
     assert all(df.A == df.C)
 


### PR DESCRIPTION
A bug in the explode function for the BinnedDataframe stage was causing problems when events were empty and a non-float column was provided (e.g. bool).  This was raised as issue #89.  This PR fixes this issue.