### PR TITLE
Tidy up final print after job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.15.0] - 2019-10-27
 ### Added
 - Existing collectors may now return their results within python, in addition to writing them to disk PR #90 [@lgray](https://github.com/lgray). 
    - This behavior can, at present, only be controlled within python, and is meant for exposing certain aspects of FAST-carpenter plumbing to [coffea](https://github.com/CoffeaTeam/coffea).
-- Tidy the print out at the end of processing, PR #94.
 
 ### Changed
 - Fix bug in BinnedDataframe stage, issue #89, PR #93 [@benkrikler](httsp://github.com/benkrikler)
 - Pin atuproot to v0.1.13, PR #91
+- Tidy the print out at the end of processing, PR #94.
 
 ## [0.14.3] - 2019-10-07
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Existing collectors may now return their results within python, in addition to writing them to disk PR #90 [@lgray](https://github.com/lgray). 
    - This behavior can, at present, only be controlled within python, and is meant for exposing certain aspects of FAST-carpenter plumbing to [coffea](https://github.com/CoffeaTeam/coffea).
+- Tidy the print out at the end of processing, PR #94.
+
 ### Changed
 - Pin atuproot to v0.1.13, PR #91
 

--- a/fast_carpenter/__main__.py
+++ b/fast_carpenter/__main__.py
@@ -75,7 +75,8 @@ def main(args=None):
     mkdir_p(args.outdir)
 
     _, ret_val = run_carpenter(sequence, datasets, args)
-    print(ret_val)
+    dfs = [df for df in ret_val[0] if df is not None]
+    print(len(dfs), "dataframes have been written to director '%s'" % args.outdir)
     return 0
 
 

--- a/fast_carpenter/version.py
+++ b/fast_carpenter/version.py
@@ -12,5 +12,5 @@ def split_version(version):
     return tuple(result)
 
 
-__version__ = '0.14.4'
+__version__ = '0.15.0'
 version_info = split_version(__version__) # noqa

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.14.4
+current_version = 0.15.0
 commit = True
 tag = False
 


### PR DESCRIPTION
Following PR #90, the command line interface prints a lot of information out at the end of the job.  This PR tidies this up.