### PR TITLE
Handle final printout when profiling

### DIFF
--- a/fast_carpenter/__main__.py
+++ b/fast_carpenter/__main__.py
@@ -75,8 +75,13 @@ def main(args=None):
     mkdir_p(args.outdir)
 
     _, ret_val = run_carpenter(sequence, datasets, args)
-    dfs = [df for df in ret_val[0] if df is not None]
-    print(len(dfs), "dataframes have been written to director '%s'" % args.outdir)
+    if not args.profile:
+        # This breaks in AlphaTwirl when used with the profile option
+        dfs = [df for df in ret_val[0] if df is not None]
+        count = len(dfs)
+    else:
+        count = "All"
+    print(count, "dataframes have been written to directory '%s'" % args.outdir)
     return 0
 
 


### PR DESCRIPTION
AlphaTwirl doesn't pass back the results of the run if used with the profiling option causing a crash at the final step in the command-line tool.  This adds a simple protection for this case.