### PR TITLE
Make alphatwirl into the first generalised "backend"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [Unreleased]
 ### Added
+- An API for different "backends" which run the actual data processing
+
 ### Changed
+- Refactor AlphaTwirl code to use the "backend" API. PR #101 [@BenKrikler](https://github.com/benkrikler)
 
 ## [0.15.1] - 2019-11-1
 ### Changed

--- a/fast_carpenter/__main__.py
+++ b/fast_carpenter/__main__.py
@@ -62,7 +62,7 @@ def main(args=None):
 
     backend = get_backend("alphatwirl")
 
-    results = backend.execute(sequence, datasets, args)
+    results, _ = backend.execute(sequence, datasets, args)
 
     print("Summary of results")
     print(results)

--- a/fast_carpenter/__main__.py
+++ b/fast_carpenter/__main__.py
@@ -57,11 +57,10 @@ def main(args=None):
     args = create_parser().parse_args(args)
 
     sequence = fast_flow.read_sequence_yaml(args.sequence_cfg, output_dir=args.outdir, backend="fast_carpenter")
-
     datasets = fast_curator.read.from_yaml(args.dataset_cfg)
-
     backend = get_backend("alphatwirl")
 
+    mkdir_p(args.outdir)
     results, _ = backend.execute(sequence, datasets, args)
 
     print("Summary of results")

--- a/fast_carpenter/backends/__init__.py
+++ b/fast_carpenter/backends/__init__.py
@@ -1,0 +1,10 @@
+from . import alphatwirl
+
+
+known_backends = {"alphatwirl": alphatwirl}
+
+
+def get_backend(name):
+    if name not in known_backends:
+        raise ValueError("Unknown backend requested, '%s'" % name)
+    return known_backends[name]

--- a/fast_carpenter/backends/alphatwirl.py
+++ b/fast_carpenter/backends/alphatwirl.py
@@ -52,7 +52,7 @@ def execute(sequence, datasets, args):
 
     if not args.profile:
         # This breaks in AlphaTwirl when used with the profile option
-        summary = {s.name: df for s, df in zip(sequence, ret_val[0]) if df is not None]
+        summary = {s.name: df.index.names for s, df in zip(sequence, ret_val[0]) if df is not None]
     else:
         summary = " (Results summary not available with profile mode) "
 

--- a/fast_carpenter/backends/alphatwirl.py
+++ b/fast_carpenter/backends/alphatwirl.py
@@ -52,7 +52,7 @@ def execute(sequence, datasets, args):
 
     if not args.profile:
         # This breaks in AlphaTwirl when used with the profile option
-        summary = {s.name: df.index.names for s, df in zip(sequence, ret_val[0]) if df is not None]
+        summary = {s[0].name: list(df.index.names) for s, df in zip(sequence, ret_val[0]) if df is not None}
     else:
         summary = " (Results summary not available with profile mode) "
 

--- a/fast_carpenter/backends/alphatwirl.py
+++ b/fast_carpenter/backends/alphatwirl.py
@@ -1,0 +1,53 @@
+"""
+Functions to run a job using alphatwirl
+"""
+
+
+class DummyCollector():
+    def collect(self, *args, **kwargs):
+        pass
+
+
+class AtuprootContext:
+    def __enter__(self):
+        import atuproot.atuproot_main as atup
+        self.atup = atup
+        self._orig_event_builder = atup.EventBuilder
+        self._orig_build_parallel = atup.build_parallel
+
+        from ..event_builder import EventBuilder
+        from atsge.build_parallel import build_parallel
+        atup.EventBuilder = EventBuilder
+        atup.build_parallel = build_parallel
+        print("BEK", self.atup.AtUproot)
+
+    def __exit__(self, *args, **kwargs):
+        self.atup.EventBuilder = self._orig_event_builder
+        self.atup.build_parallel = self._orig_build_parallel
+
+
+def execute(sequence, datasets, args):
+    """
+    Run a job using alphatwirl and atuproot
+    """
+
+    if args.ncores < 1:
+        args.ncores = 1
+
+    sequence = [(s, s.collector() if hasattr(s, "collector") else DummyCollector()) for s in sequence]
+
+    with AtuprootContext() as runner:
+        process = runner.atup.AtUproot(args.outdir,
+                                       quiet=args.quiet,
+                                       parallel_mode=args.mode,
+                                       process=args.ncores,
+                                       max_blocks_per_dataset=args.nblocks_per_dataset,
+                                       max_blocks_per_process=args.nblocks_per_sample,
+                                       nevents_per_block=args.blocksize,
+                                       profile=args.profile,
+                                       profile_out_path="profile.txt",
+                                       )
+
+        ret_val = process.run(datasets, sequence)
+
+    return sequence, ret_val

--- a/fast_carpenter/backends/alphatwirl.py
+++ b/fast_carpenter/backends/alphatwirl.py
@@ -19,7 +19,7 @@ class AtuprootContext:
         from atsge.build_parallel import build_parallel
         atup.EventBuilder = EventBuilder
         atup.build_parallel = build_parallel
-        print("BEK", self.atup.AtUproot)
+        return self
 
     def __exit__(self, *args, **kwargs):
         self.atup.EventBuilder = self._orig_event_builder

--- a/tests/backends/test_init.py
+++ b/tests/backends/test_init.py
@@ -1,0 +1,6 @@
+import fast_carpenter.backends as backends
+
+
+def test_get_backend():
+    alphatwirl_back = backends.get_backend("alphatwirl")
+    assert hasattr(alphatwirl_back, "execute")


### PR DESCRIPTION
Refactors the code that interfaces with AlphaTwirl to be just one back-end.  In the process defines what the interface for other backends will look like.  Related to #88, as well.