### PR TITLE
Add a coffea backend for local processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.16.0] - 2019-11-1
 ### Added
 - An API for different "backends" which run the actual data processing
 - Add a backed for Coffea with local-multiprocessing executor. PR #102 [@BenKrikler](https://github.com/benkrikler)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - An API for different "backends" which run the actual data processing
+- Add a backed for Coffea with local-multiprocessing executor. PR #102 [@BenKrikler](https://github.com/benkrikler)
 
 ### Changed
 - Refactor AlphaTwirl code to use the "backend" API. PR #101 [@BenKrikler](https://github.com/benkrikler)

--- a/fast_carpenter/__main__.py
+++ b/fast_carpenter/__main__.py
@@ -58,7 +58,7 @@ def main(args=None):
 
     sequence = fast_flow.read_sequence_yaml(args.sequence_cfg, output_dir=args.outdir, backend="fast_carpenter")
     datasets = fast_curator.read.from_yaml(args.dataset_cfg)
-    backend = get_backend("alphatwirl")
+    backend = get_backend("coffea")
 
     mkdir_p(args.outdir)
     results, _ = backend.execute(sequence, datasets, args)

--- a/fast_carpenter/__main__.py
+++ b/fast_carpenter/__main__.py
@@ -58,7 +58,7 @@ def main(args=None):
 
     sequence = fast_flow.read_sequence_yaml(args.sequence_cfg, output_dir=args.outdir, backend="fast_carpenter")
     datasets = fast_curator.read.from_yaml(args.dataset_cfg)
-    backend = get_backend("coffea")
+    backend = get_backend(args.mode)
 
     mkdir_p(args.outdir)
     results, _ = backend.execute(sequence, datasets, args)

--- a/fast_carpenter/backends/__init__.py
+++ b/fast_carpenter/backends/__init__.py
@@ -13,8 +13,13 @@ def get_coffea():
     return coffea
 
 
-known_backends = {"alphatwirl": get_alphatwirl,
-                  "coffea": get_coffea,
+known_backends = {"multiprocessing": get_alphatwirl,
+                  "htcondor": get_alphatwirl,
+                  "sge": get_alphatwirl,
+                  "alphatwirl:multiprocessing": get_alphatwirl,
+                  "alphatwirl:htcondor": get_alphatwirl,
+                  "alphatwirl:sge": get_alphatwirl,
+                  "coffea:local": get_coffea,
                   }
 
 

--- a/fast_carpenter/backends/__init__.py
+++ b/fast_carpenter/backends/__init__.py
@@ -1,10 +1,24 @@
-from . import alphatwirl
+"""
+Provides a common interface to select a backend
+
+Each backend is wrapped in a function so that it is only imported if requested
+"""
+def get_alphatwirl():
+    from . import alphatwirl
+    return alphatwirl
 
 
-known_backends = {"alphatwirl": alphatwirl}
+def get_coffea():
+    from . import coffea
+    return coffea
+
+
+known_backends = {"alphatwirl": get_alphatwirl,
+                  "coffea": get_coffea,
+                  }
 
 
 def get_backend(name):
     if name not in known_backends:
         raise ValueError("Unknown backend requested, '%s'" % name)
-    return known_backends[name]
+    return known_backends[name]()

--- a/fast_carpenter/backends/__init__.py
+++ b/fast_carpenter/backends/__init__.py
@@ -3,6 +3,8 @@ Provides a common interface to select a backend
 
 Each backend is wrapped in a function so that it is only imported if requested
 """
+
+
 def get_alphatwirl():
     from . import alphatwirl
     return alphatwirl

--- a/fast_carpenter/backends/coffea.py
+++ b/fast_carpenter/backends/coffea.py
@@ -86,7 +86,9 @@ def execute(sequence, datasets, args):
     fp = FASTProcessor(sequence)
 
     executor = futures_executor
-    exe_args = {'workers': 4,
+    exe_args = {'workers': args.ncores,
+                'chunksize': args.blocksize,
+                'maxchunks': args.nblocks_per_dataset,
                 'function_args': {'flatten': False}}
 
     coffea_datasets = {}

--- a/fast_carpenter/backends/coffea.py
+++ b/fast_carpenter/backends/coffea.py
@@ -1,0 +1,99 @@
+"""
+Functions to run a job using Coffea
+"""
+import copy
+from fast_carpenter.masked_tree import MaskedUprootTree
+from collections import namedtuple
+from coffea import processor
+from coffea.processor import futures_executor, run_uproot_job
+
+
+EventRanger = namedtuple("EventRanger", "start_entry stop_entry entries_in_block")
+SingleChunk = namedtuple("SingleChunk", "tree config")
+ChunkConfig = namedtuple("ChunkConfig", "dataset")
+ConfigProxy = namedtuple("ConfigProxy", "name eventtype")
+
+
+class stages_accumulator(processor.AccumulatorABC):
+    def __init__(self, stages):
+        self._zero = copy.deepcopy(stages)
+        self._value = copy.deepcopy(stages)
+    
+    def identity(self):
+        return stages_accumulator(self._zero)
+    
+    def __getitem__(self, idx):
+        return self._value[idx]
+    
+    def add(self, other):
+        for i, stage in enumerate(self._value):
+            if not hasattr(stage, "merge"):
+                continue
+            stage.merge(other[i])
+
+
+class FASTProcessor(processor.ProcessorABC):
+    def __init__(self, sequence):
+        
+        self._columns = list()
+        self._sequence = sequence
+        accumulator_dict = {'stages': processor.dict_accumulator({})}
+        self._accumulator = processor.dict_accumulator(accumulator_dict)
+
+    @property
+    def columns(self):
+        return self._columns
+    
+    @property
+    def accumulator(self):
+        return self._accumulator
+
+    def process(self, df):
+        output = self.accumulator.identity()
+        
+        start = df._branchargs['entrystart']
+        stop = df._branchargs['entrystop']
+        tree = MaskedUprootTree(df._tree, EventRanger(start, stop, stop - start))
+        dsname = df['dataset']
+        cfg_proxy = ConfigProxy(dsname, 'data' if dsname == 'data' else 'mc')
+        chunk = SingleChunk(tree, ChunkConfig(cfg_proxy))
+        
+        output['stages'][dsname] = stages_accumulator(self._sequence)
+        
+        for work in output['stages'][dsname]._value:
+            work.event(chunk)
+        
+        return output
+
+    def postprocess(self, accumulator):
+        stages = accumulator['stages']
+        results = {}
+        
+        wf = copy.deepcopy(self._sequence)
+        for i_step, step in enumerate(wf):
+            if not hasattr(step, "collector"):
+                continue        
+            collector = step.collector()
+            output = collector.collect([(d, (s[i_step],)) for d, s in stages.items()])
+            results[step.name] = output
+        
+        accumulator['results'] = results
+        
+        return accumulator
+
+
+def execute(sequence, datasets, args):
+    fp = FASTProcessor(sequence)
+
+    executor = futures_executor
+    exe_args = {'workers': 4,
+                'function_args': {'flatten': False}}
+
+    coffea_datasets = {}
+    for ds in datasets:
+        coffea_datasets[ds.name] = ds.__dict__.copy()
+        coffea_datasets[ds.name].pop('name')
+        coffea_datasets[ds.name]['treename'] = coffea_datasets[ds.name].pop('tree')
+
+    out = run_uproot_job(coffea_datasets, 'events', fp, executor, executor_args = exe_args)
+    return out["stages"], out["results"]

--- a/fast_carpenter/version.py
+++ b/fast_carpenter/version.py
@@ -12,5 +12,5 @@ def split_version(version):
     return tuple(result)
 
 
-__version__ = '0.15.1'
+__version__ = '0.16.0'
 version_info = split_version(__version__) # noqa

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.15.1
+current_version = 0.16.0
 commit = True
 tag = False
 

--- a/tests/backends/test_init.py
+++ b/tests/backends/test_init.py
@@ -1,6 +1,11 @@
+import pytest
 import fast_carpenter.backends as backends
 
 
 def test_get_backend():
     alphatwirl_back = backends.get_backend("alphatwirl:multiprocessing")
     assert hasattr(alphatwirl_back, "execute")
+
+    with pytest.raises(ValueError) as e:
+        backends.get_backend("doesn't exist")
+    assert "Unknown backend" in str(e)

--- a/tests/backends/test_init.py
+++ b/tests/backends/test_init.py
@@ -2,5 +2,5 @@ import fast_carpenter.backends as backends
 
 
 def test_get_backend():
-    alphatwirl_back = backends.get_backend("alphatwirl")
+    alphatwirl_back = backends.get_backend("alphatwirl:multiprocessing")
     assert hasattr(alphatwirl_back, "execute")

--- a/tests/summary/test_binned_dataframe.py
+++ b/tests/summary/test_binned_dataframe.py
@@ -158,7 +158,7 @@ def test_BinnedDataframe_numexpr(binned_df_3, tmpdir):
     assert binned_df_3._bin_dims[0] == "sqrt(Electron_Px**2 + Electron_Py**2)"
     assert binned_df_3._binnings[0][1] == 0.0
     assert binned_df_3._binnings[0][-2] == 200
-    assert len(binned_df_3._binnings[0]) == 2*10 + 1 + 2
+    assert len(binned_df_3._binnings[0]) == 2 * 10 + 1 + 2
     assert len(binned_df_3._weights) == 1
 
 


### PR DESCRIPTION
Adds a backend based on the interface defined from #101, that uses coffea's uproot executor, similar to AlphaTwirl's multiprocessing mode.  Related to issue #88.  Uses code originally written by @lgray in his snippet: https://gist.github.com/lgray/58cc92282168097efef9e2fab83f397a