### PR TITLE
Event by event dataframe

### DIFF
--- a/fast_carpenter/summary/eventByEvent_dataframe.py
+++ b/fast_carpenter/summary/eventByEvent_dataframe.py
@@ -1,0 +1,93 @@
+import os
+import pandas as pd
+
+
+class Collector():
+    def __init__(self, filename):
+        self.filename = filename
+
+    def collect(self, dataset_readers_list):
+
+        if len(dataset_readers_list) == 0:
+            return
+
+        output = self._prepare_output(dataset_readers_list)
+        output.to_hdf(self.filename, key='df', mode='w')
+
+    def _prepare_output(self, dataset_readers_list):
+        dataset_readers_list = [(d, [r.contents for r in readers]) for d, readers in dataset_readers_list if readers]
+        if len(dataset_readers_list) == 0:
+            return None
+
+        return self._merge_dataframes(dataset_readers_list)
+
+    def _merge_dataframes(self, dataset_readers_list):
+
+        final_df = None
+        all_dfs = []
+        keys = []
+
+        for dataset, readers in dataset_readers_list:
+            dataset_df = readers[0]
+            for df in readers[1:]:
+                if df is None:
+                    continue
+                dataset_df = dataset_df.add(df, fill_value=0.)
+
+            all_dfs.append(dataset_df)
+            keys.append(dataset)
+
+        final_df = pd.concat(all_dfs, keys=keys, names=['dataset'], sort=True)
+
+#            for reader in readers:
+#                if final_df is None: final_df = pd.concat([reader.contents], keys=[dataset], names=['dataset'])
+#                else: final_df = pd.concat([final_df, reader.contents], keys=[dataset], names=['dataset'])
+
+        return final_df.reset_index()
+
+
+class EventByEventDataframe(object):
+
+    def __init__(self, name, out_dir, collections, mask=None, flatten=True):
+
+        self.name = name
+        self.out_dir = out_dir
+        self.mask = mask
+        self.collections = collections
+        self.contents = None
+        self.df = None
+        self.flatten = flatten
+
+    def event(self, chunk):
+        variables = chunk.tree.pandas.df(self.collections, flatten=self.flatten)
+
+        variables["hashed_filename"] = hash(chunk.config.inputPaths[0])
+
+        self.df = variables
+
+        if self.contents is None:
+            self.contents = self.df
+        else:
+            self.contents = pd.concat([self.contents, self.df])
+
+        return True
+
+    def collector(self):
+
+        outfilename = "df_"
+        outfilename += self.name
+        outfilename += ".hd5"
+        outfilename = os.path.join(self.out_dir, outfilename)
+        return Collector(outfilename)
+
+    def merge(self, rhs):
+        if rhs.contents is None or len(rhs.contents) == 0:
+            return
+        if self.contents is None:
+            self.contents = rhs.contents
+            return
+        self.contents = pd.concat([self.contents, rhs.contents])
+
+
+if __name__ == "__main__":
+    print("hello")

--- a/fast_carpenter/summary/eventByEvent_dataframe.py
+++ b/fast_carpenter/summary/eventByEvent_dataframe.py
@@ -39,10 +39,6 @@ class Collector():
 
         final_df = pd.concat(all_dfs, keys=keys, names=['dataset'], sort=True)
 
-#            for reader in readers:
-#                if final_df is None: final_df = pd.concat([reader.contents], keys=[dataset], names=['dataset'])
-#                else: final_df = pd.concat([final_df, reader.contents], keys=[dataset], names=['dataset'])
-
         return final_df.reset_index()
 
 
@@ -74,9 +70,7 @@ class EventByEventDataframe(object):
 
     def collector(self):
 
-        outfilename = "df_"
-        outfilename += self.name
-        outfilename += ".hd5"
+        outfilename = "df_" + self.name + ".hd5"
         outfilename = os.path.join(self.out_dir, outfilename)
         return Collector(outfilename)
 
@@ -87,7 +81,3 @@ class EventByEventDataframe(object):
             self.contents = rhs.contents
             return
         self.contents = pd.concat([self.contents, rhs.contents])
-
-
-if __name__ == "__main__":
-    print("hello")


### PR DESCRIPTION
This PR implements the first version of the event-by-event dataframe feature.

This is how one can use it:

1) Add stage to the yaml config file:
```
    - test: fast_carpenter.EventByEventDataframe
```

2) Add the stage description, e.g.
```
unbinned:
    collections: [HT, MHT_pt, CleanJet_pt, CleanJet_eta, CleanJet_phi]
```

3) Run using usual `fast-carpenter` commands.

4) Step 3 will yield an output df in hdf5 format, that you can read this way:
```
import pandas as pd
df = pd.read_hdf("df_unbinned.hd5")
```
It has this form:
```
                        dataset   entry  subentry  CleanJet_eta  CleanJet_phi  CleanJet_pt          HT      MHT_pt     hashed_filename
0       ZJetsToNuNu_HT-400To600       0         0      2.365234     -0.485901   371.718628  491.044373  358.940094 -306183991803814303
1       ZJetsToNuNu_HT-400To600       0         1     -0.903198     -2.325684   119.325737  491.044373  358.940094 -306183991803814303
2       ZJetsToNuNu_HT-400To600       0         2      1.797363     -0.808838    23.526520  491.044373  358.940094 -306183991803814303
```
and therefore displays event by event information. The `entry` column is the event number, while subentry here corresponds to the jet number in the event.

If one would like to display collections that have different sizes (e.g. jets and muons), one can use the `flatten: False` option in the description:
```
unbinned:
    flatten: False
    collections: [HT, MHT_pt, CleanJet_pt, CleanJet_eta, CleanJet_phi, Muon_pt, Muon_eta]
```
Then the output will be of the form:
```
                    dataset  entry                                       CleanJet_eta  ...                 Muon_eta                 Muon_pt      hashed_filename
0   ZJetsToNuNu_HT-400To600      0  [2.3652344, -0.90319824, 1.7973633, 3.3046875,...  ...                       []                      []  6888980158104284518
1   ZJetsToNuNu_HT-400To600      1  [-0.54052734, -0.6665039, -0.11450195, 1.16894...  ...                       []                      []  6888980158104284518
2   ZJetsToNuNu_HT-400To600      2         [1.222168, -1.8405762, 2.03125, 1.4912109]  ...                       []                      []  6888980158104284518
3   ZJetsToNuNu_HT-400To600      3  [-0.23394775, -0.25958252, -0.03186035, 3.3632...  ...                       []                      []  6888980158104284518
4   ZJetsToNuNu_HT-400To600      4  [0.28918457, 1.2321777, -1.3066406, -4.2558594...  ...                       []                      []  6888980158104284518
5   ZJetsToNuNu_HT-400To600      7  [0.5917969, -0.24819946, -0.16210938, -0.41625...  ...                       []                      []  6888980158104284518
6   ZJetsToNuNu_HT-400To600     11                             [1.1816406, 1.5849609]  ...                       []                      []  6888980158104284518
7   ZJetsToNuNu_HT-400To600     13  [0.10227966, -0.7385254, 1.3327637, 0.5965576,...  ...                       []                      []  6888980158104284518
8   ZJetsToNuNu_HT-400To600     15  [1.0864258, -0.6040039, 0.43920898, 0.89208984...  ...            [-0.69140625]             [7.9636292]  6888980158104284518
9   ZJetsToNuNu_HT-400To600     20  [0.56689453, 0.46557617, -0.16171265, -1.12207...  ...  [0.44281006, 0.6990967]  [4.3966537, 4.0956335]  6888980158104284518
```
where each "vector" collections are stored in the output dataframe as arrays.

Please consider for merging.