### PR TITLE
Add variable broadcasting for expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.18.0] - 2020-05-07
+### Added
+- Add broadcasting between variables of different jaggedness in expressions, PR #122 [@BenKrikler](httsp://github.com/benkrikler)
+
 ## [0.17.5] - 2020-04-03
 ### Added
 - Add `observed` option to BinnedDataframe for speed boost with many bins, PR #118 [@BenKrikler](https://github.com/benkrikler)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,15 +5,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.18.0] - 2020-06-17
+### Added
+- Add broadcasting between variables of different jaggedness in expressions, PR #122 [@BenKrikler](httsp://github.com/benkrikler)
+
 ### Removed
 - Testing against Python <= 3.5, PR #124
 
 ### Fixed
 - Fix handling of empty data chunks in BinnedDataframe stage, PR #124 [@BenKrikler](https://github.com/benkrikler)
-
-## [0.18.0] - 2020-05-07
-### Added
-- Add broadcasting between variables of different jaggedness in expressions, PR #122 [@BenKrikler](httsp://github.com/benkrikler)
 
 ## [0.17.5] - 2020-04-03
 ### Added

--- a/fast_carpenter/version.py
+++ b/fast_carpenter/version.py
@@ -12,5 +12,5 @@ def split_version(version):
     return tuple(result)
 
 
-__version__ = '0.17.5'
+__version__ = '0.18.0'
 version_info = split_version(__version__) # noqa

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.17.5
+current_version = 0.18.0
 commit = True
 tag = False
 
@@ -18,4 +18,3 @@ test = pytest
 
 [tool:pytest]
 collect_ignore = ['setup.py']
-

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ def get_version():
     return _globals["__version__"]
 
 
-requirements = ['atuproot==0.1.13', 'atsge==0.2.1', 'mantichora==0.9.7',
+requirements = ['atuproot==0.1.13', 'atsge==0.2.1', 'atpbar==1.0.8', 'mantichora==0.9.7',
                 'fast-flow', 'fast-curator', 'awkward',
                 'pandas', 'numpy', 'numba', 'numexpr', 'uproot>=3']
 repositories = []

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -107,3 +107,7 @@ def test_preprocess_expression(input, expected):
     clean_expr, alias_dict = expressions.preprocess_expression(input)
     assert clean_expr == expected[0]
     assert alias_dict == expected[1]
+
+
+def test_broadcast(wrapped_tree):
+    expressions.evaluate(wrapped_tree, "NJet * Jet_Py")

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -88,9 +88,9 @@ def test_3D_jagged(wrapped_tree):
     fake_3d_2 = JaggedArray.fromiter(fake_3d_2)
     wrapped_tree.new_variable("SecondFake3D", fake_3d_2)
 
-    with pytest.raises(RuntimeError) as e:
+    with pytest.raises(ValueError) as e:
         expressions.evaluate(wrapped_tree, "SecondFake3D + Fake3D")
-    assert "different jaggedness" in str(e)
+    assert "Cannot broadcast" in str(e)
 
 
 @pytest.mark.parametrize('input, expected', [
@@ -110,4 +110,7 @@ def test_preprocess_expression(input, expected):
 
 
 def test_broadcast(wrapped_tree):
-    expressions.evaluate(wrapped_tree, "NJet * Jet_Py")
+    expressions.evaluate(wrapped_tree, "NJet * Jet_Py + NElectron * Jet_Px")
+
+    with pytest.raises(ValueError):
+        expressions.evaluate(wrapped_tree, "Jet_Py + Muon_Px")


### PR DESCRIPTION
This PR adds the functionality of variable broadcasting before passing into numexpr.
This means we can now mix variables with different jaggedness more conveniently within expressions, with less need for external stages.