### PR TITLE
Extend coffea backend support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add Dask and Parsl backends from Coffea and support execution configuration via YAML, PR #129 [@BenKrikler](https://github.com/benkrikler) and [@asnaylor](https://github.com/asnaylor)
+
 ## [0.18.2] - 2020-07-01
 ### Added
-- Add option to BinnedDataframe to apply weights to data like MC, PR #127 [@BenKrikler](httsp://github.com/benkrikler)
+- Add option to BinnedDataframe to apply weights to data like MC, PR #127 [@BenKrikler](https://github.com/benkrikler)
 
 ## [0.18.1] - 2020-06-17
 ### Fixed
@@ -15,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.18.0] - 2020-06-17
 ### Added
-- Add broadcasting between variables of different jaggedness in expressions, PR #122 [@BenKrikler](httsp://github.com/benkrikler)
+- Add broadcasting between variables of different jaggedness in expressions, PR #122 [@BenKrikler](https://github.com/benkrikler)
 
 ### Removed
 - Testing against Python <= 3.5, PR #124
@@ -76,7 +79,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    - This behavior can, at present, only be controlled within python, and is meant for exposing certain aspects of FAST-carpenter plumbing to [coffea](https://github.com/CoffeaTeam/coffea).
 
 ### Changed
-- Fix bug in BinnedDataframe stage, issue #89, PR #93 [@benkrikler](httsp://github.com/benkrikler)
+- Fix bug in BinnedDataframe stage, issue #89, PR #93 [@benkrikler](https://github.com/benkrikler)
 - Pin atuproot to v0.1.13, PR #91
 - Tidy the print out at the end of processing, PR #94.
 

--- a/fast_carpenter/__main__.py
+++ b/fast_carpenter/__main__.py
@@ -43,6 +43,9 @@ def create_parser():
                         help="Keep progress report quiet")
     parser.add_argument("--profile", default=False, action='store_true',
                         help="Profile the code")
+    parser.add_argument("--execution-cfg", "-e", default=None,
+                        help="A configuration file for the execution system.  The exact format " \
+                             "and contents of this file will depend on the value of the `--mode` option.")
     parser.add_argument("--help-stages", nargs="?", default=None, action=StagesHelp,
                         metavar="stage-name-regex",
                         help="Print help specific to the available stages")

--- a/fast_carpenter/__main__.py
+++ b/fast_carpenter/__main__.py
@@ -44,7 +44,7 @@ def create_parser():
     parser.add_argument("--profile", default=False, action='store_true',
                         help="Profile the code")
     parser.add_argument("--execution-cfg", "-e", default=None,
-                        help="A configuration file for the execution system.  The exact format " \
+                        help="A configuration file for the execution system.  The exact format "
                              "and contents of this file will depend on the value of the `--mode` option.")
     parser.add_argument("--help-stages", nargs="?", default=None, action=StagesHelp,
                         metavar="stage-name-regex",

--- a/fast_carpenter/backends/__init__.py
+++ b/fast_carpenter/backends/__init__.py
@@ -23,6 +23,7 @@ known_backends = {"multiprocessing": get_alphatwirl,
                   "alphatwirl:sge": get_alphatwirl,
                   "coffea:local": get_coffea,
                   "coffea:parsl": get_coffea,
+                  "coffea:dask": get_coffea,
                   }
 
 

--- a/fast_carpenter/backends/__init__.py
+++ b/fast_carpenter/backends/__init__.py
@@ -22,6 +22,7 @@ known_backends = {"multiprocessing": get_alphatwirl,
                   "alphatwirl:htcondor": get_alphatwirl,
                   "alphatwirl:sge": get_alphatwirl,
                   "coffea:local": get_coffea,
+                  "coffea:parsl": get_coffea,
                   }
 
 

--- a/fast_carpenter/backends/coffea.py
+++ b/fast_carpenter/backends/coffea.py
@@ -82,9 +82,12 @@ class FASTProcessor(cop.ProcessorABC):
         return accumulator
 
 
-def load_execution_cfg(cfg_file):
+def load_execution_cfg(config):
+    if not isinstance(config, str):
+        return config
+
     import yaml
-    with open(cfg_file, "r") as infile:
+    with open(config, "r") as infile:
         cfg = yaml.safe_load(infile)
         return cfg
 
@@ -128,7 +131,8 @@ def create_executor(args):
         executor = cop.parsl_executor
         exe_args.setdefault('n_threads', args.ncores)
         exe_args.setdefault('monitoring', False)
-        exe_args['config'] = configure_parsl(**exe_args)
+        if 'config' not in exe_args:
+            exe_args['config'] = configure_parsl(**exe_args)
         exe_args.setdefault('flatten', False)
     elif exe_type == "dask":
         executor = cop.dask_executor

--- a/fast_carpenter/backends/coffea.py
+++ b/fast_carpenter/backends/coffea.py
@@ -5,6 +5,7 @@ import copy
 from fast_carpenter.masked_tree import MaskedUprootTree
 from collections import namedtuple
 from coffea import processor as cop
+import logging
 
 
 EventRanger = namedtuple("EventRanger", "start_entry stop_entry entries_in_block")
@@ -99,7 +100,7 @@ def configure_parsl(n_threads, monitoring):
                                    hub_port=55055,
                                    logging_level=logging.INFO,
                                    resource_monitoring_interval=10,
-                                  )
+                                   )
     else:
         monitoring = None
 

--- a/fast_carpenter/backends/coffea.py
+++ b/fast_carpenter/backends/coffea.py
@@ -89,7 +89,7 @@ def load_execution_cfg(cfg_file):
         return cfg
 
 
-def configure_parsl(n_threads, monitoring):
+def configure_parsl(n_threads, monitoring, **kwargs):
     from parsl.config import Config
     from parsl.executors.threads import ThreadPoolExecutor
     from parsl.addresses import address_by_hostname
@@ -126,8 +126,12 @@ def create_executor(args):
         exe_args.setdefault('flatten', False)
     elif exe_type == "parsl":
         executor = cop.parsl_executor
-        exe_args.setdefault('config', configure_parsl(args.ncores, monitoring=False))
+        exe_args.setdefault('n_threads', args.ncores)
+        exe_args.setdefault('monitoring', False)
+        exe_args['config'] = configure_parsl(**exe_args)
         exe_args.setdefault('flatten', False)
+    elif exe_type == "dask":
+        executor = cop.dask_executor
     else:
         msg = "Coffea executor not yet included in fast-carpenter: '%s'"
         raise NotImplementedError(msg % exe_type)

--- a/fast_carpenter/backends/coffea.py
+++ b/fast_carpenter/backends/coffea.py
@@ -117,7 +117,7 @@ def configure_parsl(n_threads, monitoring, **kwargs):
 def create_executor(args):
     exe_type = args.mode.split(":", 1)[-1].lower()
     exe_args = {}
-    if args.execution_cfg:
+    if getattr(args, "execution_cfg", None):
         exe_args = load_execution_cfg(args.execution_cfg)
 
     if exe_type == "local":

--- a/fast_carpenter/backends/coffea.py
+++ b/fast_carpenter/backends/coffea.py
@@ -115,7 +115,7 @@ def configure_parsl(n_threads, monitoring, **kwargs):
 
 
 def create_executor(args):
-    exe_type = args.mode.split(":", 1)[1].lower()
+    exe_type = args.mode.split(":", 1)[-1].lower()
     exe_args = {}
     if args.execution_cfg:
         exe_args = load_execution_cfg(args.execution_cfg)


### PR DESCRIPTION
This PR adds support for the Dask and Parsl executors in Coffea.  This is not a complete / final implementation, but a starting point for testing.

Notes:
 * I have not yet tested the DASK executor since I am not easily set up with a Dask cluster anywhere
 * The Parsl backend has an involved configuration mechanism.  I have therefore only hooked up the "local" version of this, with a limited set of configuration options.  I think this is a decent starting point, and one we can expand on demand / need.