### PR TITLE
Remove numba dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [unreleased]
+### Fixed
+- Remove numba dependency, PR #139 [@benkrikler](https://github.com/benkrikler)
+
 ## [0.19.1] - 2020-10-13
 ### Fixed
 - Fix for uproot 3.13.0, PR #138 [@benkrikler](https://github.com/benkrikler)

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ def get_version():
 
 requirements = ['atuproot==0.1.13', 'atsge==0.2.1', 'atpbar==1.0.8', 'mantichora==0.9.7',
                 'alphatwirl==0.25.5', 'fast-flow>0.5.0', 'fast-curator', 'awkward',
-                'pandas>=1.1', 'numpy', 'numba', 'numexpr', 'uproot>=3']
+                'pandas>=1.1', 'numpy', 'numexpr', 'uproot>=3']
 repositories = []
 
 setup_requirements = ['pytest-runner', ]


### PR DESCRIPTION
Numba was included in setup.py as a dependency - but we dont use this, and it caused issues when building the documentation on readthedocs.