### PR TITLE
Issue 141 part 1: Making it work with uproot3

### DIFF
--- a/fast_carpenter/bookkeeping.py
+++ b/fast_carpenter/bookkeeping.py
@@ -26,10 +26,10 @@ _dependencies = ["pandas",
                  "pip",
                  'atpbar',
                  'mantichora',
-                 'awkward',
+                 'awkward0',
                  'numba',
                  'numexpr',
-                 'uproot',
+                 'uproot3',
                  ]
 
 

--- a/fast_carpenter/define/variables.py
+++ b/fast_carpenter/define/variables.py
@@ -3,7 +3,7 @@
 import six
 from collections import namedtuple
 import numpy as np
-from awkward import JaggedArray
+from awkward0 import JaggedArray
 from ..expressions import get_branches, evaluate
 from .reductions import get_pandas_reduction, get_awkward_reduction
 

--- a/fast_carpenter/event_builder.py
+++ b/fast_carpenter/event_builder.py
@@ -1,4 +1,4 @@
-import uproot
+import uproot3
 from atuproot.BEvents import BEvents
 from .masked_tree import MaskedUprootTree
 
@@ -69,11 +69,11 @@ class EventBuilder(object):
         # which prevent memmaps from begin created. Use a fallback - the
         # localsource option
         try:
-            rootfile = uproot.open(self.config.inputPaths[0])
+            rootfile = uproot3.open(self.config.inputPaths[0])
             tree = rootfile[self.config.treeName]
         except MemoryError:
-            rootfile = uproot.open(self.config.inputPaths[0],
-                                   localsource=uproot.FileSource.defaults)
+            rootfile = uproot3.open(self.config.inputPaths[0],
+                                   localsource=uproot3.FileSource.defaults)
             tree = rootfile[self.config.treeName]
 
         events = BEventsWrapped(tree,

--- a/fast_carpenter/event_builder.py
+++ b/fast_carpenter/event_builder.py
@@ -72,8 +72,10 @@ class EventBuilder(object):
             rootfile = uproot3.open(self.config.inputPaths[0])
             tree = rootfile[self.config.treeName]
         except MemoryError:
-            rootfile = uproot3.open(self.config.inputPaths[0],
-                                   localsource=uproot3.FileSource.defaults)
+            rootfile = uproot3.open(
+                self.config.inputPaths[0],
+                localsource=uproot3.FileSource.defaults
+            )
             tree = rootfile[self.config.treeName]
 
         events = BEventsWrapped(tree,

--- a/fast_carpenter/expressions.py
+++ b/fast_carpenter/expressions.py
@@ -2,7 +2,7 @@ import numpy as np
 import re
 import numexpr
 import tokenize
-import awkward
+import awkward0
 import logging
 try:
     from StringIO import StringIO
@@ -43,7 +43,7 @@ def get_branches(cut, valid):
 
 
 def deconstruct_jaggedness(array, counts):
-    if not isinstance(array, awkward.array.base.AwkwardArrayWithContent):
+    if not isinstance(array, awkward0.array.base.AwkwardArrayWithContent):
         return array, counts
 
     array = array.compact()
@@ -53,7 +53,7 @@ def deconstruct_jaggedness(array, counts):
 
 def reconstruct_jaggedness(array, counts):
     for count in counts:
-        array = awkward.JaggedArray.fromcounts(count, array)
+        array = awkward0.JaggedArray.fromcounts(count, array)
     return array
 
 

--- a/fast_carpenter/tree_wrapper.py
+++ b/fast_carpenter/tree_wrapper.py
@@ -5,14 +5,14 @@ way uproot works.  However, it allows me to achieve the functionality of adding
 a branch to uproot trees with no changes to actual code in uproot and with
 minimal coding on my side...
 """
-import uproot
-from uproot import asjagged, asdtype, asgenobj
+import uproot3
+from uproot3 import asjagged, asdtype, asgenobj
 import copy
-import awkward
+import awkward0
 
 
 def recursive_type_wrap(array):
-    if isinstance(array, awkward.JaggedArray):
+    if isinstance(array, awkward0.JaggedArray):
         return asjagged(recursive_type_wrap(array.content))
     return asdtype(array.dtype.fields)
 
@@ -20,15 +20,15 @@ def recursive_type_wrap(array):
 class wrapped_asgenobj(asgenobj):
     def finalize(self, *args, **kwargs):
         result = super(wrapped_asgenobj, self).finalize(*args, **kwargs)
-        result = awkward.JaggedArray.fromiter(result)
+        result = awkward0.JaggedArray.fromiter(result)
         return result
 
 
-uproot.interp.auto.asgenobj = wrapped_asgenobj
+uproot3.interp.auto.asgenobj = wrapped_asgenobj
 
 
 def wrapped_interpret(branch, *args, **kwargs):
-    from uproot.interp.auto import interpret
+    from uproot3.interp.auto import interpret
     result = interpret(branch, *args, **kwargs)
     if result:
         return result
@@ -39,11 +39,11 @@ def wrapped_interpret(branch, *args, **kwargs):
     return None
 
 
-uproot.tree.interpret = wrapped_interpret
+uproot3.tree.interpret = wrapped_interpret
 
 
 class WrappedTree(object):
-    __replace_itervalues = uproot.version.version < "3.13.0"
+    __replace_itervalues = uproot3.version.version < "3.13.0"
 
     def __init__(self, tree, event_ranger):
         self.tree = copy.copy(tree)
@@ -142,7 +142,7 @@ class WrappedTree(object):
 
         outputtype = WrappedTree.FakeBranch
 
-        name = uproot.rootio._bytesid(name)
+        name = uproot3.rootio._bytesid(name)
         self.extras[name] = outputtype(name, value, self.event_ranger)
 
     def __getattr__(self, attr):

--- a/setup.py
+++ b/setup.py
@@ -21,9 +21,21 @@ def get_version():
     return _globals["__version__"]
 
 
-requirements = ['atuproot==0.1.13', 'atsge==0.2.1', 'atpbar==1.0.8', 'mantichora==0.9.7',
-                'alphatwirl==0.25.5', 'fast-flow>0.5.0', 'fast-curator', 'awkward',
-                'pandas>=1.1', 'numpy', 'numexpr', 'uproot>=3']
+requirements = [
+    'atuproot==0.1.13',
+    'atsge==0.2.1',
+    'atpbar==1.0.8',
+    'mantichora==0.9.7',
+    'alphatwirl==0.25.5',
+    'fast-flow>0.5.0',
+    'fast-curator',
+    'awkward',
+    'pandas>=1.1',
+    'numpy',
+    'numexpr',
+    'uproot>=4.1.8',
+    'uproot3',
+]
 repositories = []
 
 setup_requirements = ['pytest-runner', ]
@@ -38,13 +50,11 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: Apache Software License',
         'Natural Language :: English',
-        "Programming Language :: Python :: 2",
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
     ],
     description="F.A.S.T. package for summarizing ROOT TTrees",
     entry_points={

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,12 @@
 import pytest
-import uproot
+import uproot3
 from collections import namedtuple
 
 
 @pytest.fixture
 def infile():
     filename = "tests/data/CMS_HEP_tutorial_ww.root"
-    return uproot.open(filename)["events"]
+    return uproot3.open(filename)["events"]
 
 
 FakeEventRange = namedtuple("FakeEventRange", "start_entry stop_entry entries_in_block")

--- a/tests/define/test_reductions.py
+++ b/tests/define/test_reductions.py
@@ -1,6 +1,6 @@
 import pytest
 import numpy as np
-from awkward import JaggedArray
+from awkward0 import JaggedArray
 import fast_carpenter.define.reductions as reductions
 
 

--- a/tests/selection/test_filters.py
+++ b/tests/selection/test_filters.py
@@ -1,7 +1,7 @@
 import pytest
 import six
 import numpy as np
-import uproot
+import uproot3
 import fast_carpenter.selection.filters as filters
 
 
@@ -24,7 +24,7 @@ def test_build_selection_1(config_1):
 
 def test_selection_1(config_1, filename):
     selection = filters.build_selection("test_selection_1", config_1)
-    infile = uproot.open(filename)["events"]
+    infile = uproot3.open(filename)["events"]
     mask = selection(infile, is_mc=False)
     assert np.count_nonzero(mask) == 289
 
@@ -58,7 +58,7 @@ def config_2():
 def test_selection_2_weights(config_2, filename):
     selection = filters.build_selection("test_selection_1",
                                         config_2, weights=["EventWeight"])
-    infile = uproot.open(filename)["events"]
+    infile = uproot3.open(filename)["events"]
     mask = selection(infile, is_mc=True)
     assert np.count_nonzero(mask) == 1486
 
@@ -78,7 +78,7 @@ def test_selection_2_weights(config_2, filename):
 def test_selection_2_weights_data(config_2, filename):
     selection = filters.build_selection("test_selection_1",
                                         config_2, weights=["EventWeight"])
-    infile = uproot.open(filename)["events"]
+    infile = uproot3.open(filename)["events"]
     mask = selection(infile, is_mc=False)
     assert np.count_nonzero(mask) == 1486
 
@@ -104,7 +104,7 @@ def config_3():
 
 def test_selection_3(config_3, filename):
     selection = filters.build_selection("test_selection_3", config_3)
-    infile = uproot.open(filename)["events"]
+    infile = uproot3.open(filename)["events"]
     mask = selection(infile, is_mc=True)
     assert np.count_nonzero(mask) == 8
 
@@ -125,7 +125,7 @@ def config_jagged_index():
 
 def test_selection_jagged_index(config_jagged_index, filename):
     selection = filters.build_selection("test_selection_jagged", config_jagged_index)
-    infile = uproot.open(filename)["events"]
+    infile = uproot3.open(filename)["events"]
     mask = selection(infile, is_mc=False)
     # Compare to: events->Draw("", "Muon_Px[1] > 0.300")
     assert len(mask) == len(infile)
@@ -139,7 +139,7 @@ def config_jagged_count_nonzero():
 
 def test_selection_jagged_count_nonzero(config_jagged_count_nonzero, filename):
     selection = filters.build_selection("test_selection_jagged", config_jagged_count_nonzero)
-    infile = uproot.open(filename)["events"]
+    infile = uproot3.open(filename)["events"]
     mask = selection(infile, is_mc=False)
     # Compare to: events->Draw("", "Sum$(Muon_Px > 0.300) > 0")
     assert np.count_nonzero(mask) == 2225

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -1,6 +1,6 @@
 import pytest
 import numpy as np
-from awkward import JaggedArray
+from awkward0 import JaggedArray
 from fast_carpenter import expressions
 
 


### PR DESCRIPTION
First part of getting this to work with uproot4 is fixing what is broken:

- renamed all `uproot` instances to `uproot3`
- renamed all `awkward` instances to `awkward0`
- removed Python 2 support
- added `uproot3` and `awkward0` to install requirements

Next: encapsulation of all uproot and awkward usage such that uproot4 can be used in parallel