### PR TITLE
Fixing issue 151

### DIFF
--- a/fast_carpenter/selection/filters.py
+++ b/fast_carpenter/selection/filters.py
@@ -54,6 +54,8 @@ class Counter():
 
     @property
     def counts(self) -> Tuple[int, float]:
+        if not self._weight_names:
+            return (self._counts,)
         return (self._counts,) + tuple(self._w_counts)
 
     def add(self, rhs) -> None:

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ requirements = [
     'awkward',
     'coffea==0.7.9',
     'pandas>=1.1',
-    'numpy==1.21.0; python_version < "3.9"',
+    'numpy==1.22.0; python_version < "3.9"',
     'numpy>= 1.18.5; python_version > "3.8"',
     'numexpr',
     'typing-extensions>=4.1.1',


### PR DESCRIPTION
This PR fixes #151 :
- setup: require `numpy==1.22` for `python < 3.9` for compatibility with `numba`
- Fix Counter: should not return weighted entries if no weights are given